### PR TITLE
Fix closing tags in works pages

### DIFF
--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -69,7 +69,6 @@
         }
     </style>
 </head>
-</head>
 <body>
     <header>
         <div class="logo">
@@ -83,5 +82,6 @@
     <p class="italic large-margin">for piano, flute, cello and electronics</p>
     <p class="large-margin">Premiere: TBD</p>
     <p class="italic large-margin"></p>        
+</main>
 </body>
 </html>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -69,7 +69,6 @@
         }
     </style>
 </head>
-</head>
 <body>
     <header>
         <div class="logo">
@@ -86,5 +85,6 @@
         <a href="https://www.leonardomatteucci.com/works/bodylines/bodylines-score_Page_05.png" class="link" style="margin-right: 10px;">Preview</a>
         <a href="https://soundcloud.com/leonardo_matteucci/bodylines-home-studio-recording/" class="link">Soundcloud</a>
     </p>   
+</main>
 </body>
 </html>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -69,7 +69,6 @@
         }
     </style>
 </head>
-</head>
 <body>
     <header>
         <div class="logo">
@@ -88,5 +87,6 @@
         <a href="https://www.leonardomatteucci.com/works/internal/internal-score_Page_05.png" class="link" style="margin-right: 10px;">Preview</a>
         <a href="https://soundcloud.com/leonardo_matteucci/internal-live-recording/" class="link">Soundcloud</a>
     </p>          
+</main>
 </body>
 </html>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -69,7 +69,6 @@
         }
     </style>
 </head>
-</head>
 <body>
     <header>
         <div class="logo">
@@ -83,5 +82,6 @@
     <p class="italic large-margin">for violin and electronics</p>
     <p class="large-margin">Premiere: TBD</p>
     <p class="italic large-margin">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>        
+</main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix extra `</head>` lines in works pages
- add missing `</main>` before `</body>` so page layout is valid

## Testing
- `python3 -m http.server 8000` & `curl -I http://localhost:8000/works/assume/index.html`
- `python3 -m http.server 8000` & `curl -I http://localhost:8000/works/bodylines/index.html`
- `python3 -m http.server 8000` & `curl -I http://localhost:8000/works/internal/index.html`
- `python3 -m http.server 8000` & `curl -I http://localhost:8000/works/occlusion/index.html`


------
https://chatgpt.com/codex/tasks/task_e_686ffe2eb358832d8f34db35ae42183a