### PR TITLE
Fix closing tags on works pages

### DIFF
--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -69,7 +69,6 @@
         }
     </style>
 </head>
-</head>
 <body>
     <header>
         <div class="logo">
@@ -82,6 +81,8 @@
     <p>Assume (2025) [15.00]</p>
     <p class="italic large-margin">for piano, flute, cello and electronics</p>
     <p class="large-margin">Premiere: TBD</p>
-    <p class="italic large-margin"></p>        
+    <p class="italic large-margin"></p>
+    </main>
 </body>
 </html>
+

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -69,7 +69,6 @@
         }
     </style>
 </head>
-</head>
 <body>
     <header>
         <div class="logo">
@@ -85,6 +84,7 @@
     <p>
         <a href="https://www.leonardomatteucci.com/works/bodylines/bodylines-score_Page_05.png" class="link" style="margin-right: 10px;">Preview</a>
         <a href="https://soundcloud.com/leonardo_matteucci/bodylines-home-studio-recording/" class="link">Soundcloud</a>
-    </p>   
+    </p>
+    </main>
 </body>
 </html>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -69,7 +69,6 @@
         }
     </style>
 </head>
-</head>
 <body>
     <header>
         <div class="logo">
@@ -87,6 +86,8 @@
     <p>
         <a href="https://www.leonardomatteucci.com/works/internal/internal-score_Page_05.png" class="link" style="margin-right: 10px;">Preview</a>
         <a href="https://soundcloud.com/leonardo_matteucci/internal-live-recording/" class="link">Soundcloud</a>
-    </p>          
+    </p>
+    </main>
 </body>
 </html>
+

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -69,7 +69,6 @@
         }
     </style>
 </head>
-</head>
 <body>
     <header>
         <div class="logo">
@@ -82,6 +81,8 @@
     <p>Occlusion (2025) [9.30]</p>
     <p class="italic large-margin">for violin and electronics</p>
     <p class="large-margin">Premiere: TBD</p>
-    <p class="italic large-margin">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>        
+    <p class="italic large-margin">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>
+    </main>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- fix duplicate `</head>` tags
- close `<main>` sections properly

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_686f759c35dc832db8064ccfc1c33833