### PR TITLE
Update SoundCloud spelling

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
                 <p>8010 Graz, Austria</p>
                 <p><a href="tel:+393932282032" class="link">+39 393 228 2032</a></p>
                 <p><a href="mailto:leonardo.matteucci@icloud.com" class="link">leonardo.matteucci@icloud.com</a></p>
-                <p><a href="https://soundcloud.com/leonardo_matteucci" class="link">Soundcloud</a></p>
+                <p><a href="https://soundcloud.com/leonardo_matteucci" class="link">SoundCloud</a></p>
             </div>
         </section>
     </main>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -22,7 +22,7 @@
     <p class="italic large-margin">A transformed body needs a new representation: what persists are the lines in its movements; there is no musical semantics, only the need to move, to breathe within it.</p>
     <p>
         <a href="https://www.leonardomatteucci.com/works/bodylines/bodylines-score_Page_05.png" class="link" style="margin-right: 10px;">Preview</a>
-        <a href="https://soundcloud.com/leonardo_matteucci/bodylines-home-studio-recording/" class="link">Soundcloud</a>
+        <a href="https://soundcloud.com/leonardo_matteucci/bodylines-home-studio-recording/" class="link">SoundCloud</a>
     </p>   
 </body>
 </html>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -24,7 +24,7 @@
     <p class="italic large-margin">Establishing a relationship with what we cannot directly interact with: our bodily interior, the joints that emerge from within, contracting, bending, compressing; to better control, anticipate, or even break them, their flexions, and finally stretch them out.</p>
     <p>
         <a href="https://www.leonardomatteucci.com/works/internal/internal-score_Page_05.png" class="link" style="margin-right: 10px;">Preview</a>
-        <a href="https://soundcloud.com/leonardo_matteucci/internal-live-recording/" class="link">Soundcloud</a>
+        <a href="https://soundcloud.com/leonardo_matteucci/internal-live-recording/" class="link">SoundCloud</a>
     </p>          
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix capitalization of SoundCloud links

## Testing
- `grep -R "SoundCloud" -n works`


------
https://chatgpt.com/codex/tasks/task_e_687000f026bc832d85b3b5492f27f01c