### PR TITLE
Restore black-and-white theme

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>About - Leonardo Matteucci</title>
+    <link rel="icon" href="../logo-favicon.svg" type="image/svg+xml">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <header>
+        <div class="logo">
+            <a href="/">
+                <img src="../logo-favicon.svg" alt="home">
+            </a>
+        </div>
+        <nav>
+            <a href="/about/" class="link">About</a>
+            <a href="/works/" class="link">Works</a>
+            <a href="/contact/" class="link">Contact</a>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h1>About</h1>
+            <p class="large-margin">Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation. He studied in Turin with Giorgio Colombo Taccani from 2019 to 2021, and in Fermo with Marco Momi from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the University of Music and Performing Arts Graz.</p>
+        </section>
+    </main>
+</body>
+</html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contact - Leonardo Matteucci</title>
+    <link rel="icon" href="../logo-favicon.svg" type="image/svg+xml">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <header>
+        <div class="logo">
+            <a href="/">
+                <img src="../logo-favicon.svg" alt="home">
+            </a>
+        </div>
+        <nav>
+            <a href="/about/" class="link">About</a>
+            <a href="/works/" class="link">Works</a>
+            <a href="/contact/" class="link">Contact</a>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h1>Contact</h1>
+            <p>8010 Graz, Austria</p>
+            <p><a href="tel:+393932282032" class="link">+39 393 228 2032</a></p>
+            <p><a href="mailto:leonardo.matteucci@icloud.com" class="link">leonardo.matteucci@icloud.com</a></p>
+            <p><a href="https://soundcloud.com/leonardo_matteucci" class="link">SoundCloud</a></p>
+        </section>
+    </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -53,31 +53,16 @@
                 <img src="logo-favicon.svg" alt="home">
             </a>
         </div>
+        <nav>
+            <a href="/about/" class="link">About</a>
+            <a href="/works/" class="link">Works</a>
+            <a href="/contact/" class="link">Contact</a>
+        </nav>
     </header>
     <main>
         <section id="about">
             <h1>About</h1>
             <p class="large-margin">Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation. He studied in Turin with Giorgio Colombo Taccani from 2019 to 2021, and in Fermo with Marco Momi from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the University of Music and Performing Arts Graz.</p>
-        </section>
-        <section id="works">
-            <h1>Works</h1>
-            <p><a href="/works/occlusion/" class="link">Occlusion</a> (2025)</p>
-            <p class="italic mid-margin">for violin and electronics</p>
-            <p><a href="/works/assume/" class="link">Assume</a> (2025)</p>
-            <p class="italic mid-margin">for piano, flute, cello and electronics</p>
-            <p><a href="/works/bodylines/" class="link">Bodylines</a> (2023)</p>
-            <p class="italic mid-margin">for violin, piccolo and electronics</p>
-            <p><a href="/works/internal/" class="link">Internal</a> (2023)</p>
-            <p class="italic mid-margin">for ensemble (8)</p>
-        </section>
-        <section id="contact">
-            <h1>Contact</h1>
-            <div class="contact-info">
-                <p>8010 Graz, Austria</p>
-                <p><a href="tel:+393932282032" class="link">+39 393 228 2032</a></p>
-                <p><a href="mailto:leonardo.matteucci@icloud.com" class="link">leonardo.matteucci@icloud.com</a></p>
-                <p><a href="https://soundcloud.com/leonardo_matteucci" class="link">SoundCloud</a></p>
-            </div>
         </section>
     </main>
 </body>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,6 +7,24 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://www.leonardomatteucci.com/about/</loc>
+    <lastmod>2024-06-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.leonardomatteucci.com/works/</loc>
+    <lastmod>2024-06-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.leonardomatteucci.com/contact/</loc>
+    <lastmod>2024-06-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://www.leonardomatteucci.com/works/bodylines/</loc>
     <lastmod>2024-06-30</lastmod>
     <changefreq>monthly</changefreq>
@@ -14,6 +32,18 @@
   </url>
   <url>
     <loc>https://www.leonardomatteucci.com/works/internal/</loc>
+    <lastmod>2024-06-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.leonardomatteucci.com/works/assume/</loc>
+    <lastmod>2024-06-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://www.leonardomatteucci.com/works/occlusion/</loc>
     <lastmod>2024-06-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/style.css
+++ b/style.css
@@ -3,8 +3,9 @@ body {
     padding: 5vh;
     font-family: 'Roboto', sans-serif;
     font-weight: 300;
-    background-color: #000000;
-    color: #ffffff;
+    background-color: #ffffff;
+    color: #000000;
+    line-height: 1.6;
 }
 header {
     display: flex;
@@ -14,27 +15,38 @@ header {
     position: fixed;
     top: 0;
     width: 100%;
-    background-color: #000000;
+    background-color: #ffffff;
+    border-bottom: 1px solid #dddddd;
     z-index: 1000;
 }
 main {
     margin-top: 90px;
+    max-width: 700px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 0 1em;
 }
 .logo img {
     width: 60px;
     height: auto;
     margin-left: -15px;
 }
+nav a {
+    margin-left: 1em;
+}
+nav a:first-child {
+    margin-left: 0;
+}
 h1 {
     font-weight: 400;
-    font-size: 1.4em;
-    margin-bottom: 0.5em;
+    font-size: 1.6em;
+    margin-bottom: 0.75em;
 }
 p {
     font-weight: 300;
     font-size: 1em;
-    margin-bottom: -0.75em;
-    line-height: 1.5em;
+    margin-bottom: 1em;
+    line-height: 1.6em;
 }
 .large-margin {
     margin-bottom: 2.5em;
@@ -46,7 +58,7 @@ p {
     font-style: italic;
 }
 .link {
-    color: #ffffff;
+    color: #000000;
     text-decoration: none;
 }
 .link:hover {
@@ -57,4 +69,14 @@ img {
     display: block;
     margin-left: auto;
     margin-right: auto;
+}
+section {
+    margin-bottom: 3em;
+}
+.works-list {
+    list-style-type: none;
+    padding: 0;
+}
+.works-list li {
+    margin-bottom: 1em;
 }

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -15,11 +15,17 @@
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
         </div>
+        <nav>
+            <a href="/about/" class="link">About</a>
+            <a href="/works/" class="link">Works</a>
+            <a href="/contact/" class="link">Contact</a>
+        </nav>
     </header>
     <main>
     <p>Assume (2025) [15.00]</p>
     <p class="italic large-margin">for piano, flute, cello and electronics</p>
     <p class="large-margin">Premiere: TBD</p>
-    <p class="italic large-margin"></p>        
+    <p class="italic large-margin"></p>
+    </main>
 </body>
 </html>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -15,6 +15,11 @@
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
         </div>
+        <nav>
+            <a href="/about/" class="link">About</a>
+            <a href="/works/" class="link">Works</a>
+            <a href="/contact/" class="link">Contact</a>
+        </nav>
     </header>
     <main>
     <p>Bodylines (2023) [7.30]</p>
@@ -23,6 +28,7 @@
     <p>
         <a href="https://www.leonardomatteucci.com/works/bodylines/bodylines-score_Page_05.png" class="link" style="margin-right: 10px;">Preview</a>
         <a href="https://soundcloud.com/leonardo_matteucci/bodylines-home-studio-recording/" class="link">SoundCloud</a>
-    </p>   
+    </p>
+    </main>
 </body>
 </html>

--- a/works/index.html
+++ b/works/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Works - Leonardo Matteucci</title>
+    <link rel="icon" href="../logo-favicon.svg" type="image/svg+xml">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+    <header>
+        <div class="logo">
+            <a href="/">
+                <img src="../logo-favicon.svg" alt="home">
+            </a>
+        </div>
+        <nav>
+            <a href="/about/" class="link">About</a>
+            <a href="/works/" class="link">Works</a>
+            <a href="/contact/" class="link">Contact</a>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h1>Works</h1>
+            <ul class="works-list">
+                <li><a href="/works/occlusion/" class="link">Occlusion</a> (2025) - <span class="italic">for violin and electronics</span></li>
+                <li><a href="/works/assume/" class="link">Assume</a> (2025) - <span class="italic">for piano, flute, cello and electronics</span></li>
+                <li><a href="/works/bodylines/" class="link">Bodylines</a> (2023) - <span class="italic">for violin, piccolo and electronics</span></li>
+                <li><a href="/works/internal/" class="link">Internal</a> (2023) - <span class="italic">for ensemble (8)</span></li>
+            </ul>
+        </section>
+    </main>
+</body>
+</html>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -15,6 +15,11 @@
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
         </div>
+        <nav>
+            <a href="/about/" class="link">About</a>
+            <a href="/works/" class="link">Works</a>
+            <a href="/contact/" class="link">Contact</a>
+        </nav>
     </header>
     <main>
     <p>Internal (2023) [10.00]</p>
@@ -25,6 +30,7 @@
     <p>
         <a href="https://www.leonardomatteucci.com/works/internal/internal-score_Page_05.png" class="link" style="margin-right: 10px;">Preview</a>
         <a href="https://soundcloud.com/leonardo_matteucci/internal-live-recording/" class="link">SoundCloud</a>
-    </p>          
+    </p>
+    </main>
 </body>
 </html>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -15,11 +15,17 @@
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
         </div>
+        <nav>
+            <a href="/about/" class="link">About</a>
+            <a href="/works/" class="link">Works</a>
+            <a href="/contact/" class="link">Contact</a>
+        </nav>
     </header>
     <main>
     <p>Occlusion (2025) [9.30]</p>
     <p class="italic large-margin">for violin and electronics</p>
     <p class="large-margin">Premiere: TBD</p>
-    <p class="italic large-margin">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>        
+    <p class="italic large-margin">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>
+    </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- resolve merge conflicts by keeping black-and-white colors
- add dedicated pages and simplified works list
- refine navigation spacing for the first link

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687002d26948832dbc4bdf5b50342002