### PR TITLE
Remove textual site title from headers

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -14,7 +14,6 @@
             <a href="/">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
-            <span class="site-title">Leonardo Matteucci</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/contact/index.html
+++ b/contact/index.html
@@ -14,7 +14,6 @@
             <a href="/">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
-            <span class="site-title">Leonardo Matteucci</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/index.html
+++ b/index.html
@@ -52,7 +52,6 @@
             <a href="/">
                 <img src="logo-favicon.svg" alt="home">
             </a>
-            <span class="site-title">Leonardo Matteucci</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/style.css
+++ b/style.css
@@ -24,12 +24,6 @@ header {
     display: flex;
     align-items: center;
 }
-.site-title {
-    margin-left: 0.5em;
-    font-size: 1.1em;
-    font-weight: 400;
-    white-space: nowrap;
-}
 main {
     margin-top: 90px;
     max-width: 700px;

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -14,7 +14,6 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="site-title">Leonardo Matteucci</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -14,7 +14,6 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="site-title">Leonardo Matteucci</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/works/index.html
+++ b/works/index.html
@@ -14,7 +14,6 @@
             <a href="/">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
-            <span class="site-title">Leonardo Matteucci</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -14,7 +14,6 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="site-title">Leonardo Matteucci</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -14,7 +14,6 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="site-title">Leonardo Matteucci</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>


### PR DESCRIPTION
## Summary
- drop `site-title` spans from all page headers
- delete unused `.site-title` CSS class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68716c996504832da4cd76bc8d7b427f