### PR TITLE
Fix news section layout and mobile header

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,24 +74,10 @@
             <h1>Leonardo Matteucci</h1>
             <p class="mid-margin">Composer &amp; Sound Artist</p>
         </section>
-        <section id="news" class="news-container">
-            <div id="news-slider">
-                <span class="news-item">July 2024 – Premiere of "Assume" at Festival X</span>
-                <span class="news-item">August 2024 – Residency at Y Institute</span>
-                <span class="news-item">December 2024 – New work for ensemble Z</span>
-                <span class="news-item">April 2025 – Performance of "Occlusion"</span>
-            </div>
-        </section>
         <section id="about">
             <h2>About</h2>
             <p class="large-margin">Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation. He studied in Turin with Giorgio Colombo Taccani from 2019 to 2021, and in Fermo with Marco Momi from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the University of Music and Performing Arts Graz.</p>
         </section>
     </main>
-    <script>
-    document.addEventListener('DOMContentLoaded', () => {
-        const slider = document.getElementById('news-slider');
-        slider.innerHTML += slider.innerHTML;
-    });
-    </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -167,27 +167,17 @@ body.home main {
     body.home main {
         margin-left: 0;
     }
-=======
-    overflow: hidden;
-    white-space: nowrap;
-    border-top: 1px solid #555555;
-    border-bottom: 1px solid #555555;
-    padding: 0.5em 0;
-    margin-bottom: 3em;
 }
 
-#news-slider {
-    display: inline-block;
-    padding-left: 100%;
-    animation: slide-left 20s linear infinite;
-}
-
-.news-item {
-    display: inline-block;
-    margin-right: 2em;
-}
-
-@keyframes slide-left {
-    from { transform: translateX(0); }
-    to { transform: translateX(-100%); }
+@media (max-width: 600px) {
+    header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    nav {
+        margin-top: 0.5em;
+    }
+    nav a {
+        margin: 0 1em 0.5em 0;
+    }
 }


### PR DESCRIPTION
## Summary
- remove animated news ticker from home page
- clean up leftover CSS merge artifacts
- add responsive header layout for small screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68716d649860832da7853536c2c1e393