### PR TITLE
Apply grey instrumentation style on works pages

### DIFF
--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -23,7 +23,7 @@
     </header>
     <main>
     <p>Assume (2025) [15.00]</p>
-    <p class="italic large-margin">for flute, piano, cello and electronics</p>
+    <p class="works-details large-margin">for flute, piano, cello and electronics</p>
     <p class="large-margin">Premiere: TBD</p>
     <p class="italic large-margin"></p>
     </main>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -23,7 +23,7 @@
     </header>
     <main>
     <p>Bodylines (2023) [7.30]</p>
-    <p class="italic large-margin">for violin, piccolo and electronics</p>
+    <p class="works-details large-margin">for violin, piccolo and electronics</p>
     <p class="italic large-margin">A transformed body needs a new representation: what persists are the lines in its movements; there is no musical semantics, only the need to move, to breathe within it.</p>
     <p>
         <a href="https://www.leonardomatteucci.com/works/bodylines/bodylines-score_Page_05.png" class="link" style="margin-right: 10px;">Preview</a>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -23,7 +23,7 @@
     </header>
     <main>
     <p>Internal (2023) [10.00]</p>
-    <p class="italic large-margin">for ensemble (8)</p>
+    <p class="works-details large-margin">for ensemble (8)</p>
     <p>Commissioned by and dedicated to Opificio Sonoro</p>
     <p class="large-margin">Premiere: 11 May 2023, Festival Orizzonti, Perugia</p>
     <p class="italic large-margin">Establishing a relationship with what we cannot directly interact with: our bodily interior, the joints that emerge from within, contracting, bending, compressing; to better control, anticipate, or even break them, their flexions, and finally stretch them out.</p>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -23,7 +23,7 @@
     </header>
     <main>
     <p>Occlusion (2025) [9.30]</p>
-    <p class="italic large-margin">for violin and electronics</p>
+    <p class="works-details large-margin">for violin and electronics</p>
     <p class="large-margin">Premiere: TBD</p>
     <p class="italic large-margin">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>
     </main>


### PR DESCRIPTION
## Summary
- use `.works-details` for instrumentation lines on work pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872056e3750832d99ce8c33db77b9be