### PR TITLE
Fix spacing of titles in work pages

### DIFF
--- a/style.css
+++ b/style.css
@@ -102,6 +102,7 @@ section {
 .works-title {
     display: block;
     font-weight: 400;
+    margin-bottom: 0;
 }
 .works-details {
     display: block;

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -22,7 +22,7 @@
         </nav>
     </header>
     <main>
-    <p>Assume (2025) [15.00]</p>
+    <p class="works-title">Assume (2025) [15.00]</p>
     <p class="works-details large-margin">for flute, piano, cello and electronics</p>
     <p class="large-margin">Premiere: TBD</p>
     <p class="italic large-margin"></p>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -22,7 +22,7 @@
         </nav>
     </header>
     <main>
-    <p>Bodylines (2023) [7.30]</p>
+    <p class="works-title">Bodylines (2023) [7.30]</p>
     <p class="works-details large-margin">for violin, piccolo and electronics</p>
     <p class="italic large-margin">A transformed body needs a new representation: what persists are the lines in its movements; there is no musical semantics, only the need to move, to breathe within it.</p>
     <p>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -22,7 +22,7 @@
         </nav>
     </header>
     <main>
-    <p>Internal (2023) [10.00]</p>
+    <p class="works-title">Internal (2023) [10.00]</p>
     <p class="works-details large-margin">for ensemble (8)</p>
     <p>Commissioned by and dedicated to Opificio Sonoro</p>
     <p class="large-margin">Premiere: 11 May 2023, Festival Orizzonti, Perugia</p>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -22,7 +22,7 @@
         </nav>
     </header>
     <main>
-    <p>Occlusion (2025) [9.30]</p>
+    <p class="works-title">Occlusion (2025) [9.30]</p>
     <p class="works-details large-margin">for violin and electronics</p>
     <p class="large-margin">Premiere: TBD</p>
     <p class="italic large-margin">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>


### PR DESCRIPTION
## Summary
- keep works list spacing consistent by zeroing the margin on `.works-title`
- apply `.works-title` class to titles inside each work page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687206843fdc832d96e91f1043910563