### PR TITLE
Update works pages with durations and instrumentation

### DIFF
--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -23,7 +23,8 @@
         </nav>
     </header>
     <main>
-    <p class="works-title">Assume (2025) [15.00]</p>
+    <p class="works-title">Assume (2025)</p>
+    <p class="works-details">Duration: 15′</p>
     <p class="works-details large-margin">for flute, piano, cello and electronics</p>
     <p class="large-margin">Premiere: 28 November 2025, [ImCubus], Graz</p>
     <p class="italic large-margin"></p>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -23,8 +23,9 @@
         </nav>
     </header>
     <main>
-    <p class="works-title">Bodylines (2023) [7.30]</p>
-    <p class="works-details large-margin">for violin, piccolo and electronics</p>
+    <p class="works-title">Bodylines (2023)</p>
+    <p class="works-details">Duration: 7′30″</p>
+    <p class="works-details large-margin">Instrumentation: Violin (+ Nebulizer tube); Piccolo (+ ACME Whistles® Silent Dog Whistle 535); fixed-media stereo electronics &ndash; 3 audio exciters (each with a stereo digital amplifier), 1 contact microphone, 1 lavalier microphone.</p>
     <p class="italic large-margin">A transformed body needs a new representation: what persists are the lines in its movements; there is no musical semantics, only the need to move, to breathe within it.</p>
     <p>
         <a href="https://www.leonardomatteucci.com/works/bodylines/bodylines-score_Page_05.png" class="link" style="margin-right: 10px;">Preview</a>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -23,8 +23,9 @@
         </nav>
     </header>
     <main>
-    <p class="works-title">Internal (2023) [10.00]</p>
-    <p class="works-details large-margin">for ensemble (8)</p>
+    <p class="works-title">Internal (2023)</p>
+    <p class="works-details">Duration: 10′</p>
+    <p class="works-details large-margin">Instrumentation: Flute (with B foot); Clarinet in B-flat; Vibraphone (+ Crotales: F#6&nbsp;G#6&nbsp;A6&nbsp;B6); Guitar; Piano (+ EBow); Accordion; Violin; Cello.</p>
     <p>Commissioned by and dedicated to Opificio Sonoro</p>
     <p class="large-margin">Premiere: 11 May 2023, Festival Orizzonti, Perugia</p>
     <p class="italic large-margin">Establishing a relationship with what we cannot directly interact with: our bodily interior, the joints that emerge from within, contracting, bending, compressing; to better control, anticipate, or even break them, their flexions, and finally stretch them out.</p>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -23,8 +23,9 @@
         </nav>
     </header>
     <main>
-    <p class="works-title">Occlusion (2025) [9.30]</p>
-    <p class="works-details large-margin">for violin and electronics</p>
+    <p class="works-title">Occlusion (2025)</p>
+    <p class="works-details">Duration: 9′30″</p>
+    <p class="works-details large-margin">Instrumentation: Violin; fixed-media stereo electronics &ndash; 1 clip-on microphone.</p>
     <p class="large-margin">Premiere: 23 June 2025, Kunstuniversität Graz</p>
     <p class="italic large-margin">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>
     </main>


### PR DESCRIPTION
## Summary
- add dedicated Duration line for each work
- expand instrumentation for Internal, Bodylines and Occlusion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f4f215b8832d940296305b8d36dd