### PR TITLE
Move tagline to header

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -14,6 +14,7 @@
             <a href="/">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
+            <span class="tagline">Composer &amp; Sound Artist</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/contact/index.html
+++ b/contact/index.html
@@ -14,6 +14,7 @@
             <a href="/">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
+            <span class="tagline">Composer &amp; Sound Artist</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/events/index.html
+++ b/events/index.html
@@ -14,6 +14,7 @@
             <a href="/">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
+            <span class="tagline">Composer &amp; Sound Artist</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
             <a href="/">
                 <img src="logo-favicon.svg" alt="home">
             </a>
+            <span class="tagline">Composer &amp; Sound Artist</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>
@@ -64,7 +65,6 @@
     <main>
         <section class="hero">
             <h1>Leonardo Matteucci</h1>
-            <p class="mid-margin">Composer &amp; Sound Artist</p>
         </section>
     </main>
 </body>

--- a/style.css
+++ b/style.css
@@ -39,6 +39,12 @@ main {
     width: 60px;
     height: auto;
 }
+.tagline {
+    margin-left: 0.75em;
+    font-size: 0.9em;
+    color: #cccccc;
+    font-style: italic;
+}
 nav a {
     margin-left: 1.5em;
     font-weight: 400;

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -14,6 +14,7 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
+            <span class="tagline">Composer &amp; Sound Artist</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -14,6 +14,7 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
+            <span class="tagline">Composer &amp; Sound Artist</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -14,6 +14,7 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
+            <span class="tagline">Composer &amp; Sound Artist</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/works/index.html
+++ b/works/index.html
@@ -14,6 +14,7 @@
             <a href="/">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
+            <span class="tagline">Composer &amp; Sound Artist</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -14,6 +14,7 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
+            <span class="tagline">Composer &amp; Sound Artist</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -14,6 +14,7 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
+            <span class="tagline">Composer &amp; Sound Artist</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>


### PR DESCRIPTION
## Summary
- remove main page tagline
- show tagline after the logo on all pages
- style tagline with smaller italic text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878fb625618832daddd2708a9209397