### PR TITLE
Add SoundCloud buttons

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -28,7 +28,7 @@
             <p>8010 Graz, Austria</p>
             <p><a href="tel:+393932282032" class="link">+39 393 228 2032</a></p>
             <p><a href="mailto:leonardo.matteucci@icloud.com" class="link">leonardo.matteucci@icloud.com</a></p>
-            <p><a href="https://soundcloud.com/leonardo_matteucci" class="link">SoundCloud</a></p>
+            <p><a href="https://soundcloud.com/leonardo_matteucci" class="button button-thin">SoundCloud</a></p>
         </section>
     </main>
 </body>

--- a/style.css
+++ b/style.css
@@ -156,6 +156,11 @@ section {
     color: #000000;
 }
 
+.button-thin {
+    padding: 0.25em 0.5em;
+    font-size: 0.9em;
+}
+
 
 @media (max-width: 600px) {
     header {

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -27,10 +27,7 @@
     <p class="works-details">for string quartet and electronics</p>
     <p class="works-details">Instrumentation: Violin I, Violin II, Viola, Violoncello; fixed-media mono electronics &ndash; no amplification needed.</p>
     <p class="italic">in memoria di Carla Massini</p>
-    <p class="large-margin">Premiere: 29 October 2021, Salone dei Concerti, Turin Conservatory</p>
-    <p>
-        <a href="https://soundcloud.com/leonardo_matteucci/a-uno-spirituale-in-firenze-live-recording" class="link">SoundCloud</a>
-    </p>
+    <p class="large-margin">Premiere: 29 October 2021, Salone dei Concerti, Turin Conservatory <a href="https://soundcloud.com/leonardo_matteucci/a-uno-spirituale-in-firenze-live-recording" class="button button-thin">SoundCloud</a></p>
     </main>
 </body>
 </html>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -26,10 +26,7 @@
     <p class="works-title">Bodylines (2023)</p>
     <p class="works-details">Duration: 7′30″</p>
     <p class="works-details large-margin">Instrumentation: Violin (+ Nebulizer tube); Piccolo (+ ACME Whistles® Silent Dog Whistle 535); fixed-media stereo electronics &ndash; 3 audio exciters (each with a stereo digital amplifier), 1 contact microphone, 1 lavalier microphone.</p>
-    <p class="italic large-margin">A transformed body needs a new representation: what persists are the lines in its movements; there is no musical semantics, only the need to move, to breathe within it.</p>
-    <p>
-        <a href="https://soundcloud.com/leonardo_matteucci/bodylines-home-studio-recording/" class="link">SoundCloud</a>
-    </p>
+    <p class="italic large-margin">A transformed body needs a new representation: what persists are the lines in its movements; there is no musical semantics, only the need to move, to breathe within it. <a href="https://soundcloud.com/leonardo_matteucci/bodylines-home-studio-recording/" class="button button-thin">SoundCloud</a></p>
     </main>
 </body>
 </html>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -27,11 +27,8 @@
     <p class="works-details">Duration: 10′</p>
     <p class="works-details large-margin">Instrumentation: Flute (with B foot); Clarinet in B-flat; Vibraphone (+ Crotales: F#6&nbsp;G#6&nbsp;A6&nbsp;B6); Guitar; Piano (+ EBow); Accordion; Violin; Cello.</p>
     <p>Commissioned by and dedicated to Opificio Sonoro</p>
-    <p class="large-margin">Premiere: 11 May 2023, Festival Orizzonti, Perugia</p>
+    <p class="large-margin">Premiere: 11 May 2023, Festival Orizzonti, Perugia <a href="https://soundcloud.com/leonardo_matteucci/internal-live-recording/" class="button button-thin">SoundCloud</a></p>
     <p class="italic large-margin">Establishing a relationship with what we cannot directly interact with: our bodily interior, the joints that emerge from within, contracting, bending, compressing; to better control, anticipate, or even break them, their flexions, and finally stretch them out.</p>
-    <p>
-        <a href="https://soundcloud.com/leonardo_matteucci/internal-live-recording/" class="link">SoundCloud</a>
-    </p>
     </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create `.button-thin` style for compact buttons
- add SoundCloud buttons next to premiere and contact text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878fc0ce3b8832db3c20f84c9b2f1e0