### PR TITLE
Fix header duplicates and update tagline

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -14,7 +14,7 @@
             <a href="/">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
-            <span class="tagline">Composer &amp; Sound Artist</span>
+            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>
@@ -22,13 +22,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/projects/" class="link">Projects</a>
-            <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
-            <a target="_blank" href="/about/" class="link">About</a>
-            <a target="_blank" href="/works/" class="link">Works</a>
-            <a target="_blank" href="/events/" class="link">Events</a>
-            <a target="_blank" href="/contact/" class="link">Contact</a>
         </nav>
     </header>
     <main>

--- a/contact/index.html
+++ b/contact/index.html
@@ -14,7 +14,7 @@
             <a href="/">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
-            <span class="tagline">Composer &amp; Sound Artist</span>
+            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>
@@ -22,12 +22,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
-            <a target="_blank" href="/about/" class="link">About</a>
-            <a target="_blank" href="/works/" class="link">Works</a>
-            <a target="_blank" href="/events/" class="link">Events</a>
-            <a target="_blank" href="/contact/" class="link">Contact</a>
         </nav>
     </header>
     <main>
@@ -37,9 +31,6 @@
             <p><a href="tel:+393932282032" class="link">+39 393 228 2032</a></p>
             <p><a href="mailto:leonardo.matteucci@icloud.com" class="link">leonardo.matteucci@icloud.com</a></p>
             <p><a href="https://soundcloud.com/leonardo_matteucci" class="button button-thin">SoundCloud</a></p>
-            <p><a target="_blank" href="tel:+393932282032" class="link">+39 393 228 2032</a></p>
-            <p><a target="_blank" href="mailto:leonardo.matteucci@icloud.com" class="link">leonardo.matteucci@icloud.com</a></p>
-            <p><a target="_blank" href="https://soundcloud.com/leonardo_matteucci" class="link">SoundCloud</a></p>
         </section>
     </main>
     <footer>

--- a/events/index.html
+++ b/events/index.html
@@ -14,7 +14,7 @@
             <a href="/">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
-            <span class="tagline">Composer &amp; Sound Artist</span>
+            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>
@@ -22,12 +22,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
-            <a target="_blank" href="/about/" class="link">About</a>
-            <a target="_blank" href="/works/" class="link">Works</a>
-            <a target="_blank" href="/events/" class="link">Events</a>
-            <a target="_blank" href="/contact/" class="link">Contact</a>
         </nav>
     </header>
     <main>

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
             <a href="/">
                 <img src="logo-favicon.svg" alt="home">
             </a>
-            <span class="tagline">Composer &amp; Sound Artist</span>
+            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>
@@ -60,12 +60,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
-            <a target="_blank" href="/about/" class="link">About</a>
-            <a target="_blank" href="/works/" class="link">Works</a>
-            <a target="_blank" href="/events/" class="link">Events</a>
-            <a target="_blank" href="/contact/" class="link">Contact</a>
         </nav>
     </header>
 

--- a/projects/index.html
+++ b/projects/index.html
@@ -18,9 +18,9 @@
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/works/" class="link">Works</a>
-            <a href="/projects/" class="link">Projects</a>
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
+            <a href="/projects/" class="link">Projects</a>
         </nav>
     </header>
     <main>

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -14,7 +14,7 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="tagline">Composer &amp; Sound Artist</span>
+            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>
@@ -22,12 +22,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
-            <a target="_blank" href="/about/" class="link">About</a>
-            <a target="_blank" href="/works/" class="link">Works</a>
-            <a target="_blank" href="/events/" class="link">Events</a>
-            <a target="_blank" href="/contact/" class="link">Contact</a>
         </nav>
     </header>
     <main>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -14,7 +14,7 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="tagline">Composer &amp; Sound Artist</span>
+            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>
@@ -22,12 +22,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
-            <a target="_blank" href="/about/" class="link">About</a>
-            <a target="_blank" href="/works/" class="link">Works</a>
-            <a target="_blank" href="/events/" class="link">Events</a>
-            <a target="_blank" href="/contact/" class="link">Contact</a>
         </nav>
     </header>
     <main>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -14,7 +14,7 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="tagline">Composer &amp; Sound Artist</span>
+            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>
@@ -22,12 +22,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
-            <a target="_blank" href="/about/" class="link">About</a>
-            <a target="_blank" href="/works/" class="link">Works</a>
-            <a target="_blank" href="/events/" class="link">Events</a>
-            <a target="_blank" href="/contact/" class="link">Contact</a>
         </nav>
     </header>
     <main>

--- a/works/index.html
+++ b/works/index.html
@@ -14,7 +14,7 @@
             <a href="/">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
-            <span class="tagline">Composer &amp; Sound Artist</span>
+            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>
@@ -22,12 +22,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
-            <a target="_blank" href="/about/" class="link">About</a>
-            <a target="_blank" href="/works/" class="link">Works</a>
-            <a target="_blank" href="/events/" class="link">Events</a>
-            <a target="_blank" href="/contact/" class="link">Contact</a>
         </nav>
     </header>
     <main>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -14,7 +14,7 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="tagline">Composer &amp; Sound Artist</span>
+            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>
@@ -22,12 +22,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
-            <a target="_blank" href="/about/" class="link">About</a>
-            <a target="_blank" href="/works/" class="link">Works</a>
-            <a target="_blank" href="/events/" class="link">Events</a>
-            <a target="_blank" href="/contact/" class="link">Contact</a>
         </nav>
     </header>
     <main>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -14,7 +14,7 @@
             <a href="/">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="tagline">Composer &amp; Sound Artist</span>
+            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
         <nav>
             <a href="/about/" class="link">About</a>
@@ -22,12 +22,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
-            <a target="_blank" href="/about/" class="link">About</a>
-            <a target="_blank" href="/works/" class="link">Works</a>
-            <a target="_blank" href="/events/" class="link">Events</a>
-            <a target="_blank" href="/contact/" class="link">Contact</a>
         </nav>
     </header>
     <main>


### PR DESCRIPTION
## Summary
- streamline headers across the site
- replace tagline text with "LEONARDO MATTEUCCI"
- remove duplicated contact details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ff58ea7c832d9a90c4ea731eaa7d