### PR TITLE
Add YouTube links for two past events

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -48,10 +48,12 @@
                 <li>
                     <span class="event-date">11 May 2023</span>
                     <span class="event-details">Internal – Opificio Sonoro, Festival Orizzonti, Perugia</span>
+                    <a class="button button-thin" href="https://www.youtube.com/watch?v=Bp2AaVuLGsc&list=RDBp2AaVuLGsc&start_radio=1">YouTube</a>
                 </li>
                 <li>
                     <span class="event-date">29 October 2021</span>
                     <span class="event-details">A uno spirituale in Firenze – Quartetto Maurice, Musical Evenings, Conservatory &quot;Giuseppe Verdi&quot;, Turin</span>
+                    <a class="button button-thin" href="https://www.youtube.com/watch?v=mtePxVfP_Iw">YouTube</a>
                 </li>
                 <li>
                     <span class="event-date">18 July 2021</span>


### PR DESCRIPTION
## Summary
- update *events/index.html* with new YouTube links for the 11 May 2023 and 29 October 2021 performances

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879288a733c832da4435e57e3116ef3