### PR TITLE
Fix duplicate bio, update styling, and add mobile menu

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -16,6 +16,8 @@
             </a>
             <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <input type="checkbox" id="menu-toggle" class="menu-toggle">
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
@@ -29,7 +31,6 @@
             <h1>About</h1>
             <p class="large-margin">Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation. He studied in Turin with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> from 2019 to 2021, and in Fermo with <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> from 2021 to 2023. He is now pursuing his Master’s in Composition under <a href="https://de.wikipedia.org/wiki/Franck_Bedrossian" target="_blank">Franck Bedrossian</a> at the <a href="https://www.kug.ac.at/en" target="_blank">University of Music and Performing Arts Graz</a>.</p>
             <p><a class="button" href="/detailed-cv.pdf" download>Download Detailed CV</a></p>
-            <p class="large-margin">Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation. He studied in Turin with Giorgio Colombo Taccani from 2019 to 2021, and in Fermo with Marco Momi from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the University of Music and Performing Arts Graz.</p>
         </section>
     </main>
     <footer>

--- a/contact/index.html
+++ b/contact/index.html
@@ -16,6 +16,8 @@
             </a>
             <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <input type="checkbox" id="menu-toggle" class="menu-toggle">
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>

--- a/events/index.html
+++ b/events/index.html
@@ -16,6 +16,8 @@
             </a>
             <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <input type="checkbox" id="menu-toggle" class="menu-toggle">
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>

--- a/index.html
+++ b/index.html
@@ -54,6 +54,8 @@
             </a>
             <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <input type="checkbox" id="menu-toggle" class="menu-toggle">
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>

--- a/projects/index.html
+++ b/projects/index.html
@@ -15,6 +15,8 @@
                 <img src="../logo-favicon.svg" alt="home">
             </a>
         </div>
+        <input type="checkbox" id="menu-toggle" class="menu-toggle">
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>

--- a/style.css
+++ b/style.css
@@ -10,7 +10,8 @@ body {
     color: #ffffff;
     line-height: 1.6;
     border-top: 1px solid #555555;
-    border-bottom: 1px solid #555555;
+    border-left: 1px solid #555555;
+    border-right: 1px solid #555555;
 }
 header {
     display: flex;
@@ -25,6 +26,14 @@ header {
     border-bottom: 1px solid #555555;
     z-index: 1000;
     letter-spacing: 0.05em;
+}
+.menu-toggle {
+    display: none;
+}
+.menu-icon {
+    display: none;
+    font-size: 1.5em;
+    color: #555555;
 }
 .logo {
     display: flex;
@@ -53,7 +62,7 @@ nav a {
     font-weight: 400;
     font-size: 0.95em;
     text-transform: uppercase;
-    color: #ffffff;
+    color: #555555;
 }
 nav a:first-child {
     margin-left: 0;
@@ -84,8 +93,11 @@ p {
 .italic {
     font-style: italic;
 }
+a {
+    color: #555555;
+}
 .link {
-    color: #ffffff;
+    color: #555555;
     text-decoration: none;
 }
 .link:hover {
@@ -117,7 +129,7 @@ section {
 .works-details {
     display: block;
     font-style: italic;
-    color: #cccccc;
+    color: #555555;
     margin-top: 0.2em;
 }
 
@@ -140,7 +152,7 @@ section {
 
 .event-details {
     display: block;
-    color: #cccccc;
+    color: #555555;
     margin-top: 0.2em;
 }
 
@@ -158,12 +170,18 @@ section {
 
 
 @media (max-width: 600px) {
-    header {
-        flex-direction: column;
-        align-items: flex-start;
+    .menu-icon {
+        display: block;
+        cursor: pointer;
     }
     nav {
+        display: none;
+        flex-direction: column;
+        width: 100%;
         margin-top: 0.5em;
+    }
+    .menu-toggle:checked + .menu-icon + nav {
+        display: flex;
     }
     nav a {
         margin: 0 1em 0.5em 0;
@@ -174,7 +192,7 @@ footer {
     text-align: center;
     padding: 2em 0;
     font-size: 0.8em;
-    color: #888888;
+    color: #555555;
 }
 
 footer p {

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -16,6 +16,8 @@
             </a>
             <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <input type="checkbox" id="menu-toggle" class="menu-toggle">
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -16,6 +16,8 @@
             </a>
             <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <input type="checkbox" id="menu-toggle" class="menu-toggle">
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -16,6 +16,8 @@
             </a>
             <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <input type="checkbox" id="menu-toggle" class="menu-toggle">
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>

--- a/works/index.html
+++ b/works/index.html
@@ -16,6 +16,8 @@
             </a>
             <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <input type="checkbox" id="menu-toggle" class="menu-toggle">
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -16,6 +16,8 @@
             </a>
             <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <input type="checkbox" id="menu-toggle" class="menu-toggle">
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -16,6 +16,8 @@
             </a>
             <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <input type="checkbox" id="menu-toggle" class="menu-toggle">
+        <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>


### PR DESCRIPTION
## Summary
- remove duplicated bio text from About page
- use one gray color for all links and details
- swap bottom border for vertical borders
- add responsive hamburger menu when screen is narrow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792a323b70832d9788c063cca370d9