### PR TITLE
Adjust menu colors and layout

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -8,7 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
-<body>
+<body class="about">
     <header>
         <div class="logo">
             <a href="/" title="Home">
@@ -19,7 +19,7 @@
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>
-            <a href="/about/" class="link">About</a>
+            <a href="/about/" class="link active">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link">Works</a>
             <a href="/events/" class="link">Events</a>
@@ -27,7 +27,7 @@
         </nav>
     </header>
     <main>
-        <section>
+        <section class="about-lines">
             <h1>About</h1>
             <p class="large-margin">Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation. He studied in Turin with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> from 2019 to 2021, and in Fermo with <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> from 2021 to 2023. He is now pursuing his Master’s in Composition under <a href="https://de.wikipedia.org/wiki/Franck_Bedrossian" target="_blank">Franck Bedrossian</a> at the <a href="https://www.kug.ac.at/en" target="_blank">University of Music and Performing Arts Graz</a>.</p>
             <p><a class="button" href="/detailed-cv.pdf" download>Download Detailed CV</a></p>

--- a/contact/index.html
+++ b/contact/index.html
@@ -23,7 +23,7 @@
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link">Works</a>
             <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
+            <a href="/contact/" class="link active">Contact</a>
         </nav>
     </header>
     <main>

--- a/events/index.html
+++ b/events/index.html
@@ -22,7 +22,7 @@
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link">Works</a>
-            <a href="/events/" class="link">Events</a>
+            <a href="/events/" class="link active">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
     </header>

--- a/projects/index.html
+++ b/projects/index.html
@@ -19,7 +19,7 @@
         <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>
             <a href="/about/" class="link">About</a>
-            <a href="/projects/" class="link">Projects</a>
+            <a href="/projects/" class="link active">Projects</a>
             <a href="/works/" class="link">Works</a>
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>

--- a/style.css
+++ b/style.css
@@ -10,8 +10,6 @@ body {
     color: #ffffff;
     line-height: 1.6;
     border-top: 1px solid #555555;
-    border-left: 1px solid #555555;
-    border-right: 1px solid #555555;
 }
 header {
     display: flex;
@@ -101,6 +99,14 @@ a, .link {
 a:hover, .link:hover, nav a:hover {
     text-decoration: underline;
 }
+header nav a {
+    color: #555555;
+}
+
+header nav a.active {
+    color: #ffffff;
+}
+
 img {
     margin-top: 10px;
     display: block;
@@ -120,6 +126,13 @@ img {
 }
 section {
     margin-bottom: 3em;
+}
+
+body.about .about-lines {
+    border-left: 1px solid #555555;
+    border-right: 1px solid #555555;
+    padding: 0 1em;
+    margin-top: 1em;
 }
 .works-list {
     list-style-type: none;
@@ -178,7 +191,7 @@ section {
 
 
 
-@media (max-width: 600px) {
+@media (max-width: 1500px) {
     .menu-icon {
         display: block;
         cursor: pointer;

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -21,7 +21,7 @@
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/works/" class="link">Works</a>
+            <a href="/works/" class="link active">Works</a>
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -21,7 +21,7 @@
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/works/" class="link">Works</a>
+            <a href="/works/" class="link active">Works</a>
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -21,7 +21,7 @@
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/works/" class="link">Works</a>
+            <a href="/works/" class="link active">Works</a>
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>

--- a/works/index.html
+++ b/works/index.html
@@ -21,7 +21,7 @@
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/works/" class="link">Works</a>
+            <a href="/works/" class="link active">Works</a>
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -21,7 +21,7 @@
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/works/" class="link">Works</a>
+            <a href="/works/" class="link active">Works</a>
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -21,7 +21,7 @@
         <nav>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/works/" class="link">Works</a>
+            <a href="/works/" class="link active">Works</a>
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>


### PR DESCRIPTION
## Summary
- highlight the active navigation link
- show the mobile menu sooner
- remove global side borders and add them only on the About page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792de62d2c832db30c8de067768467