### PR TITLE
Improve layout alignment and header menu

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -10,6 +10,7 @@
 </head>
 <body class="about">
     <header>
+        <div class="container">
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../logo-favicon.svg" alt="home">
@@ -25,17 +26,20 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
+        </div>
     </header>
     <main>
         <section class="about-lines">
             <h1>About</h1>
             <p class="mid-margin">Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation.</p>
             <p class="large-margin">He studied in Turin with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> from 2019 to 2021, and in Fermo with <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> from 2021 to 2023. He is now pursuing his Master’s in Composition under <a href="https://de.wikipedia.org/wiki/Franck_Bedrossian" target="_blank">Franck Bedrossian</a> at the <a href="https://www.kug.ac.at/en" target="_blank">University of Music and Performing Arts Graz</a>.</p>
-            <p><a class="button" href="/detailed-cv.pdf" download>Download Detailed CV</a></p>
+            <p><a class="button" href="/lm-CV.pdf" target="_blank">Download Detailed CV</a></p>
         </section>
     </main>
     <footer>
+        <div class="container">
         <p>&copy; 2024–2025 Leonardo Matteucci</p>
+            </div>
     </footer>
 </body>
 </html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
     <header>
+        <div class="container">
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../logo-favicon.svg" alt="home">
@@ -25,6 +26,7 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link active">Contact</a>
         </nav>
+        </div>
     </header>
     <main>
         <section>
@@ -44,7 +46,9 @@
         </section>
     </main>
     <footer>
+        <div class="container">
         <p>&copy; 2024–2025 Leonardo Matteucci</p>
+            </div>
     </footer>
 </body>
 </html>

--- a/events/index.html
+++ b/events/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
     <header>
+        <div class="container">
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../logo-favicon.svg" alt="home">
@@ -25,6 +26,7 @@
             <a href="/events/" class="link active">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
+        </div>
     </header>
     <main>
         <section>
@@ -65,7 +67,9 @@
         </section>
     </main>
     <footer>
+        <div class="container">
         <p>&copy; 2024–2025 Leonardo Matteucci</p>
+            </div>
     </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
 </head>
 <body class="home">
     <header>
+        <div class="container">
         <div class="logo">
             <a href="/" title="Home">
                 <img src="logo-favicon.svg" alt="home">
@@ -63,13 +64,16 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
+        </div>
     </header>
 
     <main>
         
     </main>
     <footer>
+        <div class="container">
         <p>&copy; 2024–2025 Leonardo Matteucci</p>
+            </div>
     </footer>
 </body>
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
     <header>
+        <div class="container">
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../logo-favicon.svg" alt="home">
@@ -24,6 +25,7 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
+        </div>
     </header>
     <main>
         <section>

--- a/style.css
+++ b/style.css
@@ -11,11 +11,14 @@ body {
     line-height: 1.6;
     border-top: 1px solid #555555;
 }
+
+.container {
+    max-width: 700px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 0 2vw;
+}
 header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1em 2vw;
     position: fixed;
     top: 0;
     left: 0;
@@ -23,6 +26,13 @@ header {
     background-color: #000000;
     border-bottom: 1px solid #555555;
     z-index: 1000;
+}
+
+header .container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1em 2vw;
     letter-spacing: 0.05em;
 }
 .menu-toggle {
@@ -31,7 +41,7 @@ header {
 .menu-icon {
     display: none;
     font-size: 1.5em;
-    color: #555555;
+    color: #ffffff;
 }
 .logo {
     display: flex;
@@ -100,11 +110,14 @@ a:hover, .link:hover, nav a:hover {
     text-decoration: underline;
 }
 header nav a {
-    color: #555555;
+    color: #ffffff;
+    opacity: 0.7;
+    transition: opacity 0.3s ease;
 }
 
+header nav a:hover,
 header nav a.active {
-    color: #ffffff;
+    opacity: 1;
 }
 
 img {
@@ -210,9 +223,9 @@ body.about .about-lines {
     }
 }
 
-footer {
+footer .container {
     text-align: center;
-    padding: 2em 0;
+    padding: 2em 2vw;
     font-size: 0.8em;
     color: #555555;
 }

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
     <header>
+        <div class="container">
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../../logo-favicon.svg" alt="logo">
@@ -25,6 +26,7 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
+        </div>
     </header>
     <main>
     <p class="works-title">A uno spirituale in Firenze (2021)</p>
@@ -38,7 +40,9 @@
     </p>
     </main>
     <footer>
+        <div class="container">
         <p>&copy; 2024–2025 Leonardo Matteucci</p>
+            </div>
     </footer>
 </body>
 </html>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
     <header>
+        <div class="container">
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../../logo-favicon.svg" alt="logo">
@@ -25,6 +26,7 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
+        </div>
     </header>
     <main>
     <p class="works-title">Assume (2025)</p>
@@ -34,7 +36,9 @@
     <p class="italic large-margin"></p>
     </main>
     <footer>
+        <div class="container">
         <p>&copy; 2024–2025 Leonardo Matteucci</p>
+            </div>
     </footer>
 </body>
 </html>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
     <header>
+        <div class="container">
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../../logo-favicon.svg" alt="logo">
@@ -25,6 +26,7 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
+        </div>
     </header>
     <main>
     <p class="works-title">Bodylines (2023)</p>
@@ -36,7 +38,9 @@
     </p>
     </main>
     <footer>
+        <div class="container">
         <p>&copy; 2024–2025 Leonardo Matteucci</p>
+            </div>
     </footer>
 </body>
 </html>

--- a/works/index.html
+++ b/works/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
     <header>
+        <div class="container">
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../logo-favicon.svg" alt="home">
@@ -25,6 +26,7 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
+        </div>
     </header>
     <main>
         <section>
@@ -54,7 +56,9 @@
         </section>
     </main>
     <footer>
+        <div class="container">
         <p>&copy; 2024–2025 Leonardo Matteucci</p>
+            </div>
     </footer>
 </body>
 </html>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
     <header>
+        <div class="container">
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../../logo-favicon.svg" alt="logo">
@@ -25,6 +26,7 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
+        </div>
     </header>
     <main>
     <p class="works-title">Internal (2023)</p>
@@ -38,7 +40,9 @@
     </p>
     </main>
     <footer>
+        <div class="container">
         <p>&copy; 2024–2025 Leonardo Matteucci</p>
+            </div>
     </footer>
 </body>
 </html>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
     <header>
+        <div class="container">
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../../logo-favicon.svg" alt="logo">
@@ -25,6 +26,7 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
+        </div>
     </header>
     <main>
     <p class="works-title">Occlusion (2025)</p>
@@ -34,7 +36,9 @@
     <p class="italic large-margin">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>
     </main>
     <footer>
+        <div class="container">
         <p>&copy; 2024–2025 Leonardo Matteucci</p>
+            </div>
     </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap header and footer content in a fixed width container
- open the detailed CV in a new tab
- style menu icon and menu links in white with a fade animation
- add reusable container class and center footer text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687931db80bc832d8f28e44eb9182a2b