### PR TITLE
Remove Bedrossian Wikipedia link

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -32,7 +32,7 @@
         <section class="about-lines">
             <h1>About</h1>
             <p class="mid-margin">Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation.</p>
-            <p class="large-margin">He studied in Turin with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> from 2019 to 2021, and in Fermo with <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> from 2021 to 2023. He is now pursuing his Master’s in Composition under <a href="https://de.wikipedia.org/wiki/Franck_Bedrossian" target="_blank">Franck Bedrossian</a> at the <a href="https://www.kug.ac.at/en" target="_blank">University of Music and Performing Arts Graz</a>.</p>
+            <p class="large-margin">He studied in Turin with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> from 2019 to 2021, and in Fermo with <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the <a href="https://www.kug.ac.at/en" target="_blank">University of Music and Performing Arts Graz</a>.</p>
             <p><a class="button" href="/lm-CV.pdf" target="_blank">Download Detailed CV</a></p>
         </section>
     </main>


### PR DESCRIPTION
## Summary
- remove Wikipedia link for Franck Bedrossian on about page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793e005204832dba7c862d81a31b6b