### PR TITLE
Add link on about tagline

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -15,7 +15,7 @@
             <a href="/" title="Home">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
-            <span class="tagline">LEONARDO MATTEUCCI</span>
+            <a href="/" title="Home" class="tagline">LEONARDO MATTEUCCI</a>
         </div>
         <div class="header-icons">
             <a href="mailto:leonardo.matteucci@icloud.com" title="Personal Email">


### PR DESCRIPTION
## Summary
- link tagline text on the About page to the homepage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68795de4af0c832d97e104c2cf19a038