### PR TITLE
Improve header and footer

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -15,8 +15,8 @@
             <a href="/" title="Home">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
-            <a href="/" title="Home" class="tagline">LEONARDO MATTEUCCI</a>
         </div>
+        <span class="tagline">LEONARDO MATTEUCCI</span>
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>
@@ -32,7 +32,7 @@
             <h1>About</h1>
             <p class="mid-margin">Born in Perugia, Italy, in 2000, <a href="/">Leonardo Matteucci</a> is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation.</p>
             <p class="large-margin">He studied in Turin with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> from 2019 to 2021, and in Fermo with <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the <a href="https://www.kug.ac.at/en" target="_blank">University of Music and Performing Arts Graz</a>.</p>
-            <p><a class="button" href="/lm-CV.pdf" target="_blank">Download Detailed CV</a></p>
+            <p><a class="button" href="/lm-CV.pdf" target="_blank"><img src="../logos/pdf_file-logo_white.svg" alt="PDF" style="vertical-align:middle;width:16px;height:16px;margin-right:0.3em;">Full CV</a></p>
         </section>
     </main>
     <footer>

--- a/events/index.html
+++ b/events/index.html
@@ -15,8 +15,8 @@
             <a href="/" title="Home">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
-            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <span class="tagline">LEONARDO MATTEUCCI</span>
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>

--- a/index.html
+++ b/index.html
@@ -53,8 +53,8 @@
             <a href="/" title="Home">
                 <img src="logo-favicon.svg" alt="home">
             </a>
-            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <span class="tagline">LEONARDO MATTEUCCI</span>
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>

--- a/logos/pdf_file-logo_white.svg
+++ b/logos/pdf_file-logo_white.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="#fff" d="M6 2h7l5 5v15a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1zM13 3.5V8h4.5L13 3.5z"/>
+  <path fill="#fff" d="M7 13h2v5H7zM10 13h1.5a1.5 1.5 0 0 1 0 3H10v2H8v-5h2zM13.5 13H16a2 2 0 0 1 0 4h-2.5v-4zm1.5 1v2H16a1 1 0 0 0 0-2h-1z"/>
+</svg>

--- a/projects/index.html
+++ b/projects/index.html
@@ -16,6 +16,7 @@
                 <img src="../logo-favicon.svg" alt="home">
             </a>
         </div>
+        <span class="tagline">LEONARDO MATTEUCCI</span>
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>

--- a/style.css
+++ b/style.css
@@ -10,6 +10,7 @@ body {
     color: #ffffff;
     line-height: 1.6;
     border-top: 1px solid #555555;
+    padding-bottom: 120px;
 }
 
 .container {
@@ -33,6 +34,7 @@ header .container {
     align-items: center;
     padding: 1em 2vw;
     letter-spacing: 0.05em;
+    position: relative;
 }
 .menu-toggle {
     display: none;
@@ -93,7 +95,9 @@ main {
     height: auto;
 }
 .tagline {
-    margin-left: 0.75em;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
     font-size: 1em;
     color: #ffffff;
     font-style: normal;
@@ -248,24 +252,37 @@ body.about .about-lines {
     }
     nav {
         display: none;
+        position: absolute;
+        top: 100%;
+        right: 2vw;
+        background-color: #000000;
         flex-direction: column;
-        width: 100%;
+        align-items: flex-end;
+        width: auto;
         margin-top: 0.5em;
     }
     .menu-toggle:checked + .menu-icon + nav {
         display: flex;
     }
     nav a {
-        margin: 0 1em 0.5em 0;
+        margin: 0 0 0.5em 0;
     }
+}
+
+footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: #000000;
+    border-top: 1px solid #555555;
 }
 
 footer .container {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: space-between;
     gap: 1em;
-    text-align: center;
     padding: 2em 2vw;
     font-size: 0.8em;
     color: #555555;

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -15,8 +15,8 @@
             <a href="/" title="Home">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <span class="tagline">LEONARDO MATTEUCCI</span>
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -15,8 +15,8 @@
             <a href="/" title="Home">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <span class="tagline">LEONARDO MATTEUCCI</span>
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -15,8 +15,8 @@
             <a href="/" title="Home">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <span class="tagline">LEONARDO MATTEUCCI</span>
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>

--- a/works/dopo-lo-schianto-ci-chiamavamo/index.html
+++ b/works/dopo-lo-schianto-ci-chiamavamo/index.html
@@ -15,8 +15,8 @@
             <a href="/" title="Home">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <span class="tagline">LEONARDO MATTEUCCI</span>
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>

--- a/works/index.html
+++ b/works/index.html
@@ -15,8 +15,8 @@
             <a href="/" title="Home">
                 <img src="../logo-favicon.svg" alt="home">
             </a>
-            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <span class="tagline">LEONARDO MATTEUCCI</span>
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -15,8 +15,8 @@
             <a href="/" title="Home">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <span class="tagline">LEONARDO MATTEUCCI</span>
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -15,8 +15,8 @@
             <a href="/" title="Home">
                 <img src="../../logo-favicon.svg" alt="logo">
             </a>
-            <span class="tagline">LEONARDO MATTEUCCI</span>
         </div>
+        <span class="tagline">LEONARDO MATTEUCCI</span>
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon">&#9776;</label>
         <nav>


### PR DESCRIPTION
## Summary
- add `pdf_file-logo_white.svg` and use it in the CV link
- refactor all headers so the name is centred between the logo and the menu
- fix mobile navigation so it opens on the right
- keep footer fixed at the bottom with icons on the right

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687966c14d08832da9416726c593d52e