### PR TITLE
Update events page style and about section

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -30,8 +30,10 @@
     <main>
         <section class="about-lines">
             <h1>About</h1>
-            <p class="mid-margin">Born in Perugia, Italy, in 2000, <a href="/">Leonardo Matteucci</a> is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation.</p>
-            <p class="large-margin">He studied in Turin with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> from 2019 to 2021, and in Fermo with <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the <a href="https://www.kug.ac.at/en" target="_blank">University of Music and Performing Arts Graz</a>.</p>
+            <div class="about-text">
+                <p class="mid-margin">Born in Perugia, Italy, in 2000, <a href="/">Leonardo Matteucci</a> is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation.</p>
+                <p class="large-margin">He studied in Turin with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> from 2019 to 2021, and in Fermo with <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
+            </div>
             <p><a class="button" href="/lm-CV.pdf" target="_blank"><img src="../logos/pdf_file-logo_white.svg" alt="PDF" style="vertical-align:middle;width:16px;height:16px;margin-right:0.3em;">Full CV</a></p>
         </section>
     </main>

--- a/events/index.html
+++ b/events/index.html
@@ -33,34 +33,34 @@
             <h2>Upcoming</h2>
             <ul class="events-list">
                 <li>
-                    <span class="event-date">28 November 2025, 19:30</span>
-                    <span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a> – Aleksandra Kornowicz, KULTUM [imCubus], Graz (AT)</span>
+                    <span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a> <span class="separator">&bull;</span> violin: Aleksandra Kornowicz</span>
+                    <span class="event-date">28 November 2025, 19:30 <span class="separator">&bull;</span> [imCubus], KULTUM, [imCubus], Graz (AT)</span>
                 </li>
                 <li>
-                    <span class="event-date">28 November 2025, 19:30</span>
-                    <span class="event-details"><a href="/works/assume/" class="link">Assume</a> – Miho Sakuma, Maria Iaiza, Irati Leoz, KULTUM [imCubus], Graz (AT)</span>
+                    <span class="event-details"><a href="/works/assume/" class="link">Assume</a> <span class="separator">&bull;</span> flute: Miho Sakuma, piano: Maria Iaiza, cello: Irati Leoz</span>
+                    <span class="event-date">28 November 2025, 19:30 <span class="separator">&bull;</span> [imCubus], KULTUM, [imCubus], Graz (AT)</span>
                 </li>
                 <li>
-                    <span class="event-date">23 June 2025, 19:00</span>
-                    <span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a> – Aleksandra Kornowicz, Hermann-Markus-Preßl-Saal, Graz (AT)</span>
+                    <span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a> <span class="separator">&bull;</span> violin: Aleksandra Kornowicz</span>
+                    <span class="event-date">23 June 2025, 19:00 <span class="separator">&bull;</span> Hermann-Markus-Preßl-Saal, Kunstuniversität Graz, Graz (AT)</span>
                 </li>
             </ul>
             <hr class="events-separator">
             <h2>Past</h2>
             <ul class="events-list">
                 <li>
-                    <span class="event-date">11 May 2023, 20:30</span>
-                    <span class="event-details"><a href="/works/internal/" class="link">Internal</a> – <a href="https://www.opificiosonoro.com/" target="_blank">Opificio Sonoro</a>, Festival Orizzonti, Auditorium Santa Cecilia, Perugia (IT)</span>
+                    <span class="event-details"><a href="/works/internal/" class="link">Internal</a> <span class="separator">&bull;</span> ensemble: <a href="https://www.opificiosonoro.com/" target="_blank">Opificio Sonoro</a></span>
+                    <span class="event-date">11 May 2023, 20:30 <span class="separator">&bull;</span> Festival Orizzonti, Auditorium Santa Cecilia, Perugia (IT)</span>
                     <a class="button button-thin" href="https://www.youtube.com/watch?v=Bp2AaVuLGsc&list=RDBp2AaVuLGsc&start_radio=1">YouTube</a>
                 </li>
                 <li>
-                <span class="event-date">29 October 2021, 20:30</span>
-                    <span class="event-details"><a href="/works/a-uno-spirituale-in-firenze/" class="link">A uno spirituale in Firenze</a> – <a href="https://www.quartettomaurice.com/en" target="_blank">Quartetto Maurice</a>, Musical Evenings, Conservatory &quot;Giuseppe Verdi&quot;, Turin (IT)</span>
+                    <span class="event-details"><a href="/works/a-uno-spirituale-in-firenze/" class="link">A uno spirituale in Firenze</a> <span class="separator">&bull;</span> string quartet: <a href="https://www.quartettomaurice.com/en" target="_blank">Quartetto Maurice</a></span>
+                    <span class="event-date">29 October 2021, 20:30 <span class="separator">&bull;</span> Musical Evenings, Conservatory &quot;Giuseppe Verdi&quot;, Turin (IT)</span>
                     <a class="button button-thin" href="https://www.youtube.com/watch?v=mtePxVfP_Iw">YouTube</a>
                 </li>
                 <li>
-                    <span class="event-date">18 July 2021</span>
-                    <span class="event-details"><a href="/works/dopo-lo-schianto-ci-chiamavamo/" class="link">Dopo lo schianto, ci chiamavamo</a> – <a href="https://www.collettivo21.com/" target="_blank">Collettivo_21</a>, Foresty International Music Festival, Casa della Musica San Michele, Montaldeo (IT)</span>
+                    <span class="event-details"><a href="/works/dopo-lo-schianto-ci-chiamavamo/" class="link">Dopo lo schianto, ci chiamavamo</a> <span class="separator">&bull;</span> ensemble: <a href="https://www.collettivo21.com/" target="_blank">Collettivo_21</a></span>
+                    <span class="event-date">18 July 2021 <span class="separator">&bull;</span> Foresty International Music Festival, Casa della Musica San Michele, Montaldeo (IT)</span>
                 </li>
             </ul>
         </section>

--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Home - Leonardo Matteucci</title>
-    <meta name="description" content="Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation. He studied in Turin with Giorgio Colombo Taccani from 2019 to 2021, and in Fermo with Marco Momi from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the University of Music and Performing Arts Graz.">
+    <meta name="description" content="Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation. He studied in Turin with Giorgio Colombo Taccani from 2019 to 2021, and in Fermo with Marco Momi from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the Kunstuniversität Graz.">
     <link rel="icon" href="logo-favicon.svg" type="image/svg+xml">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Leonardo Matteucci">
-    <meta property="og:description" content="Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation. He studied in Turin with Giorgio Colombo Taccani from 2019 to 2021, and in Fermo with Marco Momi from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the University of Music and Performing Arts Graz.">
+    <meta property="og:description" content="Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation. He studied in Turin with Giorgio Colombo Taccani from 2019 to 2021, and in Fermo with Marco Momi from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the Kunstuniversität Graz.">
     <meta property="og:image" content="https://www.leonardomatteucci.com/logo-favicon.svg">
     <meta property="og:url" content="https://www.leonardomatteucci.com">
     <script type="application/ld+json">
@@ -29,7 +29,7 @@
       "alumniOf": [
         {
           "@type": "CollegeOrUniversity",
-          "name": "University of Music and Performing Arts Graz"
+          "name": "Kunstuniversität Graz"
         },
         {
           "@type": "CollegeOrUniversity",

--- a/style.css
+++ b/style.css
@@ -76,7 +76,7 @@ header .container {
 }
 .footer-icons {
     display: flex;
-    gap: 0.5em;
+    gap: 0.7em;
     margin: 0;
 }
 .footer-icons img {
@@ -180,13 +180,19 @@ img {
 }
 section {
     margin-bottom: 3em;
+    border-right: 1px solid #555555;
+    padding-right: 1em;
 }
 
 body.about .about-lines {
-    border-left: 1px solid #555555;
     border-right: 1px solid #555555;
     padding: 0 1em;
     margin-top: 1em;
+}
+
+.about-text {
+    border-left: 3px solid #555555;
+    padding-left: 1em;
 }
 .works-list {
     list-style-type: none;
@@ -228,8 +234,12 @@ body.about .about-lines {
 
 .event-details {
     display: block;
-    color: #555555;
     margin-top: 0.2em;
+}
+
+.separator {
+    color: #555555;
+    padding: 0 0.3em;
 }
 
 .events-separator {


### PR DESCRIPTION
## Summary
- adjust event texts and locations
- switch institution references to "Kunstuniversität Graz"
- style events list using bullet separators
- tweak footer icon spacing
- restructure about section with thick and thin borders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796ef77008832db0f31f8b1e6e5db5