### PR TITLE
Fix duplicated event location text

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -34,11 +34,11 @@
             <ul class="events-list">
                 <li>
                     <span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a> <span class="separator">&bull;</span> violin: Aleksandra Kornowicz</span>
-                    <span class="event-date">28 November 2025, 19:30 <span class="separator">&bull;</span> [imCubus], KULTUM, [imCubus], Graz (AT)</span>
+                    <span class="event-date">28 November 2025, 19:30 <span class="separator">&bull;</span> KULTUM, [imCubus], Graz (AT)</span>
                 </li>
                 <li>
                     <span class="event-details"><a href="/works/assume/" class="link">Assume</a> <span class="separator">&bull;</span> flute: Miho Sakuma, piano: Maria Iaiza, cello: Irati Leoz</span>
-                    <span class="event-date">28 November 2025, 19:30 <span class="separator">&bull;</span> [imCubus], KULTUM, [imCubus], Graz (AT)</span>
+                    <span class="event-date">28 November 2025, 19:30 <span class="separator">&bull;</span> KULTUM, [imCubus], Graz (AT)</span>
                 </li>
                 <li>
                     <span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a> <span class="separator">&bull;</span> violin: Aleksandra Kornowicz</span>


### PR DESCRIPTION
## Summary
- fix duplicated `[imCubus]` in event description so the venue reads `KULTUM, [imCubus], Graz (AT)`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687975c0e634832da8de1f59eaef486a