### PR TITLE
Remove deprecated theme toggle

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -25,7 +25,6 @@
             <a href="/works/" class="link">Works</a>
             <a href="/events/" class="link">Events</a>
         </nav>
-    <button id="theme-toggle" title="Toggle light/dark">🌓</button>
         </div>
     </header>
     <main>
@@ -60,6 +59,5 @@
             </div>
         </div>
     </footer>
-<script src="/theme-toggle.js"></script>
 </body>
 </html>

--- a/events/index.html
+++ b/events/index.html
@@ -25,7 +25,6 @@
             <a href="/works/" class="link">Works</a>
             <a href="/events/" class="link active">Events</a>
         </nav>
-    <button id="theme-toggle" title="Toggle light/dark">🌓</button>
         </div>
     </header>
     <main>
@@ -88,6 +87,5 @@
             </div>
         </div>
     </footer>
-<script src="/theme-toggle.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,6 @@
             <a href="/works/" class="link">Works</a>
             <a href="/events/" class="link">Events</a>
         </nav>
-    <button id="theme-toggle" title="Toggle light/dark">🌓</button>
         </div>
     </header>
 
@@ -92,6 +91,5 @@
             </div>
         </div>
     </footer>
-<script src="/theme-toggle.js"></script>
 </body>
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -25,7 +25,6 @@
             <a href="/works/" class="link">Works</a>
             <a href="/events/" class="link">Events</a>
         </nav>
-    <button id="theme-toggle" title="Toggle light/dark">🌓</button>
         </div>
     </header>
     <main>
@@ -56,6 +55,5 @@
             </div>
         </div>
     </footer>
-<script src="/theme-toggle.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -302,20 +302,3 @@ footer p {
     margin: 0;
 }
 
-/* Light/Dark theme toggle */
-#theme-toggle {
-    background: none;
-    border: none;
-    color: inherit;
-    margin-left: 1em;
-    cursor: pointer;
-    font-size: 1em;
-}
-
-body.light-mode {
-    filter: invert(1) hue-rotate(180deg);
-}
-
-body.light-mode img {
-    filter: invert(1) hue-rotate(180deg);
-}

--- a/theme-toggle.js
+++ b/theme-toggle.js
@@ -1,8 +1,0 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const btn = document.getElementById('theme-toggle');
-  if (btn) {
-    btn.addEventListener('click', () => {
-      document.body.classList.toggle('light-mode');
-    });
-  }
-});

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -26,7 +26,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
-    <button id="theme-toggle" title="Toggle light/dark">🌓</button>
         </div>
     </header>
     <main>
@@ -61,6 +60,5 @@
             </div>
         </div>
     </footer>
-<script src="/theme-toggle.js"></script>
 </body>
 </html>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -26,7 +26,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
-    <button id="theme-toggle" title="Toggle light/dark">🌓</button>
         </div>
     </header>
     <main>
@@ -58,6 +57,5 @@
             </div>
         </div>
     </footer>
-<script src="/theme-toggle.js"></script>
 </body>
 </html>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -26,7 +26,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
-    <button id="theme-toggle" title="Toggle light/dark">🌓</button>
         </div>
     </header>
     <main>
@@ -60,6 +59,5 @@
             </div>
         </div>
     </footer>
-<script src="/theme-toggle.js"></script>
 </body>
 </html>

--- a/works/dopo-lo-schianto-ci-chiamavamo/index.html
+++ b/works/dopo-lo-schianto-ci-chiamavamo/index.html
@@ -26,7 +26,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
-    <button id="theme-toggle" title="Toggle light/dark">🌓</button>
         </div>
     </header>
     <main>
@@ -57,6 +56,5 @@
             </div>
         </div>
     </footer>
-<script src="/theme-toggle.js"></script>
 </body>
 </html>

--- a/works/index.html
+++ b/works/index.html
@@ -25,7 +25,6 @@
             <a href="/works/" class="link active">Works</a>
             <a href="/events/" class="link">Events</a>
         </nav>
-    <button id="theme-toggle" title="Toggle light/dark">🌓</button>
         </div>
     </header>
     <main>
@@ -77,6 +76,5 @@
             </div>
         </div>
     </footer>
-<script src="/theme-toggle.js"></script>
 </body>
 </html>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -26,7 +26,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
-    <button id="theme-toggle" title="Toggle light/dark">🌓</button>
         </div>
     </header>
     <main>
@@ -62,6 +61,5 @@
             </div>
         </div>
     </footer>
-<script src="/theme-toggle.js"></script>
 </body>
 </html>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -26,7 +26,6 @@
             <a href="/events/" class="link">Events</a>
             <a href="/contact/" class="link">Contact</a>
         </nav>
-    <button id="theme-toggle" title="Toggle light/dark">🌓</button>
         </div>
     </header>
     <main>
@@ -58,6 +57,5 @@
             </div>
         </div>
     </footer>
-<script src="/theme-toggle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- drop unused `theme-toggle.js`
- remove CSS for the light/dark mode toggle
- delete theme toggle buttons and scripts from pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a3682619c832d821faffa13b362a1