### PR TITLE
Update CV link icon placement

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -34,7 +34,7 @@
                 <p class="mid-margin">Born in Perugia, Italy, in 2000, <a href="/">Leonardo Matteucci</a> is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation.</p>
                 <p class="large-margin">He studied in Turin with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> from 2019 to 2021, and in Fermo with <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
             </div>
-            <p><a class="button" href="/lm-CV.pdf" target="_blank"><img src="../logos/pdf_file-logo_white.svg" alt="PDF" style="vertical-align:middle;width:16px;height:16px;margin-right:0.3em;">Full CV</a></p>
+            <p><a class="button" href="/lm-CV.pdf" target="_blank">Full CV <img src="../logos/pdf_file-logo_white.svg" alt="PDF" style="vertical-align:middle;width:20px;height:20px;margin-left:0.3em;"></a></p>
         </section>
     </main>
     <footer>


### PR DESCRIPTION
## Summary
- move the PDF icon after the **Full CV** text
- enlarge the icon to 20×20 px

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a37c63cd0832dbb36255893dd23b9