### PR TITLE
Fix CV button layout

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -34,7 +34,11 @@
                 <p class="mid-margin">Born in Perugia, Italy, in 2000, <a href="/">Leonardo Matteucci</a> is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation.</p>
                 <p class="large-margin">He studied in Turin with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> from 2019 to 2021, and in Fermo with <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
             </div>
-            <p><a class="button" href="/lm-CV.pdf" target="_blank">Full CV <img src="../logos/pdf_file-logo_white.svg" alt="PDF" style="vertical-align:middle;width:20px;height:20px;margin-left:0.3em;"></a></p>
+            <p>
+                <a class="button" href="/lm-CV.pdf" target="_blank">
+                    Full CV <img src="../logos/pdf_file-logo_white.svg" alt="PDF">
+                </a>
+            </p>
         </section>
     </main>
     <footer>

--- a/style.css
+++ b/style.css
@@ -167,6 +167,17 @@ img {
     margin-left: auto;
     margin-right: auto;
 }
+.button {
+    display: inline-flex;
+    align-items: center;
+}
+
+.button img {
+    width: 24px;
+    height: 24px;
+    margin: 0 0 0 0.3em;
+    display: inline-block;
+}
 .social-icons {
     display: flex;
     gap: 1em;


### PR DESCRIPTION
## Summary
- show PDF icon next to the "Full CV" text on the about page
- add CSS rules for `.button` links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a38da7e24832d9172673c2cff09b3