### PR TITLE
Fix about section width alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -196,8 +196,6 @@ section {
 }
 
 body.about .about-lines {
-    border-right: 1px solid #555555;
-    padding: 0 1em;
     margin-top: 1em;
 }
 


### PR DESCRIPTION
## Summary
- remove extra padding from `.about-lines` so the about page aligns with other sections

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a3c41b468832d974ef371a828a698