### PR TITLE
Fix menu link across works

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -24,7 +24,6 @@
             <a href="/projects/" class="link active">Projects</a>
             <a href="/works/" class="link">Works</a>
             <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
         </nav>
         </div>
     </header>

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -24,7 +24,6 @@
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
             <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
         </nav>
         </div>
     </header>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -24,7 +24,6 @@
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
             <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
         </nav>
         </div>
     </header>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -24,7 +24,6 @@
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
             <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
         </nav>
         </div>
     </header>

--- a/works/dopo-lo-schianto-ci-chiamavamo/index.html
+++ b/works/dopo-lo-schianto-ci-chiamavamo/index.html
@@ -24,7 +24,6 @@
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
             <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
         </nav>
         </div>
     </header>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -24,7 +24,6 @@
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
             <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
         </nav>
         </div>
     </header>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -24,7 +24,6 @@
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
             <a href="/events/" class="link">Events</a>
-            <a href="/contact/" class="link">Contact</a>
         </nav>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- remove the Contact menu item from pages under `works/` and projects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a3cfa0cec832d9cbd7096fe5ba67d