### PR TITLE
Fix CV link alignment

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -34,7 +34,7 @@
                 <p class="mid-margin">Born in Perugia, Italy, in 2000, <a href="/">Leonardo Matteucci</a> is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation.</p>
                 <p class="large-margin">He studied in Turin with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> from 2019 to 2021, and in Fermo with <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
             </div>
-            <p>
+            <p class="align-right">
                 <a class="button" href="/lm-CV.pdf" target="_blank">
                     Full CV <img src="../logos/pdf_file-logo_white.svg" alt="PDF">
                 </a>

--- a/style.css
+++ b/style.css
@@ -178,6 +178,10 @@ img {
     margin: 0 0 0 0.3em;
     display: inline-block;
 }
+
+.align-right {
+    text-align: right;
+}
 .social-icons {
     display: flex;
     gap: 1em;


### PR DESCRIPTION
## Summary
- align Full CV link to the right on the About page
- add `.align-right` CSS helper class

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a3d75f764832dbe192e7166b7465c