### PR TITLE
Update events page layout

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -29,6 +29,7 @@
     </header>
     <main>
         <section>
+            <h1>Events</h1>
             <h2>Upcoming Events</h2>
             <ul class="events-list">
                 <li>
@@ -39,14 +40,14 @@
                     <span class="event-details"><a href="/works/assume/" class="link">Assume</a> <span class="separator">&bull;</span> flute: Miho Sakuma, piano: Maria Iaiza, cello: Irati Leoz</span>
                     <span class="event-date">28 November 2025, 19:30 <span class="separator">&bull;</span> KULTUM, [imCubus], Graz (AT)</span>
                 </li>
-                <li>
-                    <span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a> <span class="separator">&bull;</span> violin: Aleksandra Kornowicz</span>
-                    <span class="event-date">23 June 2025, 19:00 <span class="separator">&bull;</span> Hermann-Markus-Preßl-Saal, Kunstuniversität Graz, Graz (AT)</span>
-                </li>
             </ul>
             <hr class="events-separator">
             <h2>Past Events</h2>
             <ul class="events-list">
+                <li>
+                    <span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a> <span class="separator">&bull;</span> violin: Aleksandra Kornowicz</span>
+                    <span class="event-date">23 June 2025, 19:00 <span class="separator">&bull;</span> Hermann-Markus-Preßl-Saal, Kunstuniversität Graz, Graz (AT)</span>
+                </li>
                 <li>
                     <span class="event-details"><a href="/works/internal/" class="link">Internal</a> <span class="separator">&bull;</span> ensemble: <a href="https://www.opificiosonoro.com/" target="_blank">Opificio Sonoro</a></span>
                     <span class="event-date">11 May 2023, 20:30 <span class="separator">&bull;</span> Festival Orizzonti, Auditorium Santa Cecilia, Perugia (IT)</span>


### PR DESCRIPTION
## Summary
- move the June 2025 Occlusion event into the past events list
- add an `Events` page header so titles share the same styling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a41a45860832d97f8832ce8d1792d