### PR TITLE
Fix footer alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -310,7 +310,7 @@ footer {
 footer .container {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: space-between;
     gap: 1em;
     padding: 2em 2vw;
     font-size: 0.8em;


### PR DESCRIPTION
## Summary
- restore previous spacing between copyright and logos by reverting horizontal centering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4325fd6c832daff0c59b4ee6b034