### PR TITLE
Center logo images vertically

### DIFF
--- a/style.css
+++ b/style.css
@@ -167,6 +167,10 @@ img {
     margin-left: auto;
     margin-right: auto;
 }
+.logo img,
+.footer-icons img {
+    margin-top: 0;
+}
 .button {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- adjust CSS so header and footer logo images ignore generic top margin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a44658838832dab29697f228fdec4