### PR TITLE
Fix hero image scaling

### DIFF
--- a/style.css
+++ b/style.css
@@ -275,6 +275,13 @@ body.about .about-lines {
     font-size: 2em;
 }
 
+.hero img {
+    width: 100%;
+    height: auto;
+    max-height: 100vh;
+    object-fit: contain;
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- ensure hero image scales down to fit the viewport by limiting its max height in `style.css`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a48620210832da80311857da02ecd