### PR TITLE
Update events titles

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -29,8 +29,7 @@
     </header>
     <main>
         <section>
-            <h1>Events</h1>
-            <h2>Upcoming Events</h2>
+            <h1>Upcoming Events</h1>
             <ul class="events-list">
                 <li>
                     <span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a> <span class="separator">&bull;</span> violin: Aleksandra Kornowicz</span>
@@ -42,7 +41,7 @@
                 </li>
             </ul>
             <hr class="events-separator">
-            <h2>Past Events</h2>
+            <h1>Past Events</h1>
             <ul class="events-list">
                 <li>
                     <span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a> (W.P.) <span class="separator">&bull;</span> violin: Aleksandra Kornowicz</span>


### PR DESCRIPTION
## Summary
- remove the generic Events heading
- promote Upcoming Events and Past Events sections to `h1`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4d9435a0832d9761a47183e9ca9f