### PR TITLE
Improve work pages layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -231,8 +231,8 @@ body.about .about-lines {
 }
 .works-details {
     display: block;
-    font-style: italic;
-    color: #555555;
+    font-style: normal;
+    color: #ffffff;
     margin-top: 0.2em;
 }
 
@@ -266,6 +266,12 @@ body.about .about-lines {
 }
 
 .events-separator {
+    border: 0;
+    border-top: 1px solid #555555;
+    margin: 2em 0;
+}
+
+.works-separator {
     border: 0;
     border-top: 1px solid #555555;
     margin: 2em 0;

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -31,7 +31,7 @@
     <p class="works-title">A uno spirituale in Firenze (2021)</p>
     <p class="works-details">for string quartet and electronics</p>
     <p class="works-details">Instrumentation: Violin I, Violin II, Viola, Violoncello; fixed-media mono electronics &ndash; no amplification needed.</p>
-    <p class="italic">in memoria di Carla Massini</p>
+    <p>in memoria di Carla Massini</p>
     <p class="large-margin">Premiere: 29 October 2021, 20:30, Salone dei Concerti, Turin Conservatory</p>
     <p>
         <a target="_blank" href="https://soundcloud.com/leonardo_matteucci/a-uno-spirituale-in-firenze-live-recording" class="link">SoundCloud</a>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -32,6 +32,7 @@
     <p class="works-details">Duration: 15′</p>
     <p class="works-details large-margin">for flute, piano, cello and electronics</p>
     <p class="large-margin">Premiere: 28 November 2025, [ImCubus], Graz</p>
+    <hr class="works-separator">
     <p class="italic large-margin"></p>
     </main>
     <footer>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -31,6 +31,7 @@
     <p class="works-title">Bodylines (2023)</p>
     <p class="works-details">Duration: 7′30″</p>
     <p class="works-details large-margin">Instrumentation: Violin (+ Nebulizer tube); Piccolo (+ ACME Whistles® Silent Dog Whistle 535); fixed-media stereo electronics &ndash; 3 audio exciters (each with a stereo digital amplifier), 1 contact microphone, 1 lavalier microphone.</p>
+    <hr class="works-separator">
     <p class="italic large-margin">A transformed body needs a new representation: what persists are the lines in its movements; there is no musical semantics, only the need to move, to breathe within it.</p>
     <p>
         <a target="_blank" href="https://soundcloud.com/leonardo_matteucci/bodylines-home-studio-recording/" class="link">SoundCloud</a>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -33,6 +33,7 @@
     <p class="works-details large-margin">Instrumentation: Flute (with B foot); Clarinet in B-flat; Vibraphone (+ Crotales: F#6&nbsp;G#6&nbsp;A6&nbsp;B6); Guitar; Piano (+ EBow); Accordion; Violin; Cello.</p>
     <p>Commissioned by and dedicated to <a href="https://www.opificiosonoro.com/" target="_blank">Opificio Sonoro</a></p>
     <p class="large-margin">Premiere: 11 May 2023, Festival Orizzonti, Perugia</p>
+    <hr class="works-separator">
     <p class="italic large-margin">Establishing a relationship with what we cannot directly interact with: our bodily interior, the joints that emerge from within, contracting, bending, compressing; to better control, anticipate, or even break them, their flexions, and finally stretch them out.</p>
     <p>
         <a target="_blank" href="https://soundcloud.com/leonardo_matteucci/internal-live-recording/" class="link">SoundCloud</a>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -32,6 +32,7 @@
     <p class="works-details">Duration: 9′30″</p>
     <p class="works-details large-margin">Instrumentation: Violin; fixed-media stereo electronics &ndash; 1 clip-on microphone.</p>
     <p class="large-margin">Premiere: 23 June 2025, Kunstuniversität Graz</p>
+    <hr class="works-separator">
     <p class="italic large-margin">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>
     </main>
     <footer>


### PR DESCRIPTION
## Summary
- keep works info text white and not italic
- add a `works-separator` horizontal rule
- show the separator before program notes on each work page
- remove italics from dedication on *A uno spirituale in Firenze*

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a8a52a03c832db2eff6f188654ea9