### PR TITLE
Improve instrumentation layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -236,6 +236,19 @@ body.about .about-lines {
     margin-top: 0.2em;
 }
 
+/* List used for the instrumentation of each work */
+.instrumentation-list {
+    list-style-type: none;
+    padding-left: 1em;
+    margin-top: 0;
+    margin-bottom: 2.5em;
+    border-left: 3px solid #555555;
+}
+
+.instrumentation-list li {
+    margin-bottom: 0.2em;
+}
+
 .events-list {
     list-style-type: none;
     padding: 0;

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -30,7 +30,13 @@
     <main>
     <p class="works-title">A uno spirituale in Firenze (2021)</p>
     <p class="works-details">for string quartet and electronics</p>
-    <p class="works-details">Instrumentation: Violin I, Violin II, Viola, Violoncello; fixed-media mono electronics &ndash; no amplification needed.</p>
+    <ul class="instrumentation-list">
+        <li>Violin I</li>
+        <li>Violin II</li>
+        <li>Viola</li>
+        <li>Violoncello</li>
+        <li>fixed-media mono electronics &ndash; no amplification needed</li>
+    </ul>
     <p>in memoria di Carla Massini</p>
     <p class="large-margin">Premiere: 29 October 2021, 20:30, Salone dei Concerti, Turin Conservatory</p>
     <p>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -30,7 +30,12 @@
     <main>
     <p class="works-title">Assume (2025)</p>
     <p class="works-details">Duration: 15′</p>
-    <p class="works-details large-margin">for flute, piano, cello and electronics</p>
+    <ul class="instrumentation-list large-margin">
+        <li>Flute</li>
+        <li>Piano</li>
+        <li>Cello</li>
+        <li>Electronics</li>
+    </ul>
     <p class="large-margin">Premiere: 28 November 2025, [ImCubus], Graz</p>
     <hr class="works-separator">
     <p class="italic large-margin"></p>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -30,7 +30,11 @@
     <main>
     <p class="works-title">Bodylines (2023)</p>
     <p class="works-details">Duration: 7′30″</p>
-    <p class="works-details large-margin">Instrumentation: Violin (+ Nebulizer tube); Piccolo (+ ACME Whistles® Silent Dog Whistle 535); fixed-media stereo electronics &ndash; 3 audio exciters (each with a stereo digital amplifier), 1 contact microphone, 1 lavalier microphone.</p>
+    <ul class="instrumentation-list large-margin">
+        <li>Violin (+ Nebulizer tube)</li>
+        <li>Piccolo (+ ACME Whistles® Silent Dog Whistle 535)</li>
+        <li>fixed-media stereo electronics &ndash; 3 audio exciters (each with a stereo digital amplifier), 1 contact microphone, 1 lavalier microphone</li>
+    </ul>
     <hr class="works-separator">
     <p class="italic large-margin">A transformed body needs a new representation: what persists are the lines in its movements; there is no musical semantics, only the need to move, to breathe within it.</p>
     <p>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -30,7 +30,16 @@
     <main>
     <p class="works-title">Internal (2023)</p>
     <p class="works-details">Duration: 10′</p>
-    <p class="works-details large-margin">Instrumentation: Flute (with B foot); Clarinet in B-flat; Vibraphone (+ Crotales: F#6&nbsp;G#6&nbsp;A6&nbsp;B6); Guitar; Piano (+ EBow); Accordion; Violin; Cello.</p>
+    <ul class="instrumentation-list large-margin">
+        <li>Flute (with B foot)</li>
+        <li>Clarinet in B-flat</li>
+        <li>Vibraphone (+ Crotales: F#6&nbsp;G#6&nbsp;A6&nbsp;B6)</li>
+        <li>Guitar</li>
+        <li>Piano (+ EBow)</li>
+        <li>Accordion</li>
+        <li>Violin</li>
+        <li>Cello</li>
+    </ul>
     <p>Commissioned by and dedicated to <a href="https://www.opificiosonoro.com/" target="_blank">Opificio Sonoro</a></p>
     <p class="large-margin">Premiere: 11 May 2023, Festival Orizzonti, Perugia</p>
     <hr class="works-separator">

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -30,7 +30,10 @@
     <main>
     <p class="works-title">Occlusion (2025)</p>
     <p class="works-details">Duration: 9′30″</p>
-    <p class="works-details large-margin">Instrumentation: Violin; fixed-media stereo electronics &ndash; 1 clip-on microphone.</p>
+    <ul class="instrumentation-list large-margin">
+        <li>Violin</li>
+        <li>fixed-media stereo electronics &ndash; 1 clip-on microphone</li>
+    </ul>
     <p class="large-margin">Premiere: 23 June 2025, Kunstuniversität Graz</p>
     <hr class="works-separator">
     <p class="italic large-margin">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>


### PR DESCRIPTION
## Summary
- display each instrument on its own line
- add instrumentation list style
- refactor instrumentation text for works pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a8bd53ac0832dbacb0795055ef08e