### PR TITLE
Update Bodylines page with gear list and player

### DIFF
--- a/style.css
+++ b/style.css
@@ -249,6 +249,21 @@ body.about .about-lines {
     margin-bottom: 0.2em;
 }
 
+/* Additional list for electronics gear within works pages */
+.gear-list {
+    list-style-type: none;
+    padding-left: 1em;
+    margin: 0.2em 0 0 0;
+}
+
+.gear-list li {
+    margin-bottom: 0.2em;
+}
+
+.soundcloud-player {
+    margin: 1em 0;
+}
+
 .events-list {
     list-style-type: none;
     padding: 0;

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -33,13 +33,20 @@
     <ul class="instrumentation-list large-margin">
         <li>Violin (+ Nebulizer tube)</li>
         <li>Piccolo (+ ACME Whistles® Silent Dog Whistle 535)</li>
-        <li>fixed-media stereo electronics &ndash; 3 audio exciters (each with a stereo digital amplifier), 1 contact microphone, 1 lavalier microphone</li>
+        <li>
+            fixed-media stereo electronics
+            <ul class="gear-list">
+                <li>3 audio exciters</li>
+                <li>1 contact microphone</li>
+                <li>1 lavalier microphone</li>
+            </ul>
+        </li>
     </ul>
     <hr class="works-separator">
     <p class="italic large-margin">A transformed body needs a new representation: what persists are the lines in its movements; there is no musical semantics, only the need to move, to breathe within it.</p>
-    <p>
-        <a target="_blank" href="https://soundcloud.com/leonardo_matteucci/bodylines-home-studio-recording/" class="link">SoundCloud</a>
-    </p>
+    <div class="soundcloud-player">
+        <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/bodylines-home-studio-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
+    </div>
     </main>
     <footer>
         <div class="container">


### PR DESCRIPTION
## Summary
- tweak Bodylines instrumentation list
- embed SoundCloud player for Bodylines recording
- style new gear list and SoundCloud player

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a8dd25178832db1a1e35044f83114