### PR TITLE
Update works pages styling and instrumentation

### DIFF
--- a/style.css
+++ b/style.css
@@ -232,7 +232,7 @@ body.about .about-lines {
 .works-details {
     display: block;
     font-style: normal;
-    color: #ffffff;
+    color: #bbbbbb;
     margin-top: 0.2em;
 }
 
@@ -254,6 +254,7 @@ body.about .about-lines {
     list-style-type: none;
     padding-left: 1em;
     margin: 0.2em 0 0 0;
+    border-left: 3px double #555555;
 }
 
 .gear-list li {

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -32,7 +32,7 @@
     <p class="works-details">Duration: 7′30″</p>
     <ul class="instrumentation-list large-margin">
         <li>Violin (+ Nebulizer tube)</li>
-        <li>Piccolo (+ ACME Whistles® Silent Dog Whistle 535)</li>
+        <li>Piccolo (+ ACME Whistles<sup>®</sup> Silent Dog Whistle 535)</li>
         <li>
             fixed-media stereo electronics
             <ul class="gear-list">

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -33,12 +33,18 @@
     <ul class="instrumentation-list large-margin">
         <li>Flute (with B foot)</li>
         <li>Clarinet in B-flat</li>
-        <li>Vibraphone (+ Crotales: F#6&nbsp;G#6&nbsp;A6&nbsp;B6)</li>
+        <li>Percussion</li>
         <li>Guitar</li>
         <li>Piano (+ EBow)</li>
         <li>Accordion</li>
         <li>Violin</li>
         <li>Cello</li>
+        <li>
+            electronics
+            <ul class="gear-list">
+                <li>Vibraphone and Crotales (F&#x266F;<sup>6</sup>&nbsp;G&#x266F;<sup>6</sup>&nbsp;A<sup>6</sup>&nbsp;B<sup>6</sup>)</li>
+            </ul>
+        </li>
     </ul>
     <p>Commissioned by and dedicated to <a href="https://www.opificiosonoro.com/" target="_blank">Opificio Sonoro</a></p>
     <p class="large-margin">Premiere: 11 May 2023, Festival Orizzonti, Perugia</p>


### PR DESCRIPTION
## Summary
- gray out work instrumentation
- display ® mark in superscript
- update Internal instrumentation with percussion and electronic gear
- add double-line style for second-indent gear lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a978e5b0c832db97251a16696daa9