### PR TITLE
Embed SoundCloud players

### DIFF
--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -39,9 +39,9 @@
     </ul>
     <p>in memoria di Carla Massini</p>
     <p class="large-margin">Premiere: 29 October 2021, 20:30, Salone dei Concerti, Turin Conservatory</p>
-    <p>
-        <a target="_blank" href="https://soundcloud.com/leonardo_matteucci/a-uno-spirituale-in-firenze-live-recording" class="link">SoundCloud</a>
-    </p>
+    <div class="soundcloud-player">
+        <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/a-uno-spirituale-in-firenze-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
+    </div>
     </main>
     <footer>
         <div class="container">

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -44,9 +44,9 @@
     <p class="large-margin">Premiere: 11 May 2023, Festival Orizzonti, Perugia</p>
     <hr class="works-separator">
     <p class="italic large-margin">Establishing a relationship with what we cannot directly interact with: our bodily interior, the joints that emerge from within, contracting, bending, compressing; to better control, anticipate, or even break them, their flexions, and finally stretch them out.</p>
-    <p>
-        <a target="_blank" href="https://soundcloud.com/leonardo_matteucci/internal-live-recording/" class="link">SoundCloud</a>
-    </p>
+    <div class="soundcloud-player">
+        <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/internal-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
+    </div>
     </main>
     <footer>
         <div class="container">


### PR DESCRIPTION
## Summary
- embed the SoundCloud player for *A uno spirituale in Firenze*
- embed the SoundCloud player for *Internal*

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a97fa006c832dad2c5883d9ddc5be