### PR TITLE
Fix header overlap by restoring padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -32,7 +32,7 @@ header {
 header .container {
     display: flex;
     align-items: center;
-    padding: 2em 2vw;
+    padding: 1em 2vw;
     letter-spacing: 0.05em;
     position: relative;
 }


### PR DESCRIPTION
## Summary
- reduce `header .container` padding so that the header height matches the footer and no longer overlaps with the page content

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a99f3ed20832da05770139891eda2