### PR TITLE
Fix gear list indent thickness

### DIFF
--- a/style.css
+++ b/style.css
@@ -255,7 +255,7 @@ body.about .about-lines {
     padding-left: 1em;
     margin: 0.2em 0 0 0;
     border-left: 3px solid #555555;
-    box-shadow: -6px 0 0 #555555;
+    /* match thickness of primary indentation lines */
 }
 
 .gear-list li {


### PR DESCRIPTION
## Summary
- remove double thickness from gear list indent line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9ada2ee4832dae7d65d177227b5e