### PR TITLE
Replace musical symbols with SVGs

### DIFF
--- a/logos/flat.svg
+++ b/logos/flat.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <g stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round">
+    <path d="M12 2v20"/>
+    <path d="M12 10c2-1 4 1 4 3s-2 4-4 3"/>
+  </g>
+</svg>

--- a/logos/sharp.svg
+++ b/logos/sharp.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <g stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round">
+    <path d="M7 2v20"/>
+    <path d="M17 2v20"/>
+    <path d="M2 9h20"/>
+    <path d="M2 15h20"/>
+  </g>
+</svg>

--- a/style.css
+++ b/style.css
@@ -182,6 +182,12 @@ img {
     margin: 0 0 0 0.3em;
     display: inline-block;
 }
+.music-icon {
+    width: 1em;
+    height: 1em;
+    display: inline-block;
+    vertical-align: middle;
+}
 
 .align-right {
     text-align: right;

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -32,12 +32,12 @@
     <p class="works-details">Duration: 10′</p>
     <ul class="instrumentation-list large-margin">
         <li>Flute (with B foot)</li>
-        <li>Clarinet in B&#x266D;</li>
+        <li>Clarinet in B<img src="../../logos/flat.svg" alt="flat" class="music-icon"></li>
         <li>
             Percussion
             <ul class="gear-list">
                 <li>Vibraphone</li>
-                <li>Crotales (F&#x266F;<sup>6</sup>&nbsp;G&#x266F;<sup>6</sup>&nbsp;A<sup>6</sup>&nbsp;B<sup>6</sup>)</li>
+                <li>Crotales (F<img src="../../logos/sharp.svg" alt="sharp" class="music-icon"><sup>6</sup>&nbsp;G<img src="../../logos/sharp.svg" alt="sharp" class="music-icon"><sup>6</sup>&nbsp;A<sup>6</sup>&nbsp;B<sup>6</sup>)</li>
             </ul>
         </li>
         <li>Guitar</li>


### PR DESCRIPTION
## Summary
- add sharp.svg and flat.svg icons
- swap HTML entity flats/sharps with inline images
- style the music icon size and alignment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aac133fb8832db71a2c091af92cca