### PR TITLE
Fix EBow trademark formatting

### DIFF
--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -44,7 +44,7 @@
         <li>
             Piano
             <ul class="gear-list">
-                <li>Heet Sound® EBow Plus</li>
+                <li>Heet Sound<sup>®</sup> EBow Plus</li>
             </ul>
         </li>
         <li>Accordion</li>


### PR DESCRIPTION
## Summary
- ensure registered trademark uses superscript on the 'Internal' project page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aaf439e0c832d82982bbec9b98087