### PR TITLE
Fix Bodylines instrumentation and add section layout

### DIFF
--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -28,6 +28,7 @@
         </div>
     </header>
     <main>
+    <section>
     <p class="works-title">A uno spirituale in Firenze (2021)</p>
     <p class="works-details">for string quartet and electronics</p>
     <ul class="instrumentation-list">
@@ -42,6 +43,7 @@
     <div class="soundcloud-player">
         <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/a-uno-spirituale-in-firenze-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
     </div>
+    </section>
     </main>
     <footer>
         <div class="container">

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -28,6 +28,7 @@
         </div>
     </header>
     <main>
+    <section>
     <p class="works-title">Assume (2025)</p>
     <p class="works-details">Duration: 15′</p>
     <ul class="instrumentation-list large-margin">
@@ -39,6 +40,7 @@
     <p class="large-margin">Premiere: 28 November 2025, [ImCubus], Graz</p>
     <hr class="works-separator">
     <p class="italic large-margin"></p>
+    </section>
     </main>
     <footer>
         <div class="container">

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -28,11 +28,22 @@
         </div>
     </header>
     <main>
+    <section>
     <p class="works-title">Bodylines (2023)</p>
     <p class="works-details">Duration: 7′30″</p>
     <ul class="instrumentation-list large-margin">
-        <li>Violin (+ Nebulizer tube)</li>
-        <li>Piccolo (+ ACME Whistles<sup>®</sup> Silent Dog Whistle 535)</li>
+        <li>
+            Violin
+            <ul class="gear-list">
+                <li>Nebulizer tube</li>
+            </ul>
+        </li>
+        <li>
+            Piccolo
+            <ul class="gear-list">
+                <li>ACME Whistles<sup>®</sup> Silent Dog Whistle 535</li>
+            </ul>
+        </li>
         <li>
             fixed-media stereo electronics
             <ul class="gear-list">
@@ -47,6 +58,7 @@
     <div class="soundcloud-player">
         <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/bodylines-home-studio-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
     </div>
+    </section>
     </main>
     <footer>
         <div class="container">

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -28,6 +28,7 @@
         </div>
     </header>
     <main>
+    <section>
     <p class="works-title">Internal (2023)</p>
     <p class="works-details">Duration: 10′</p>
     <ul class="instrumentation-list large-margin">
@@ -58,6 +59,7 @@
     <div class="soundcloud-player">
         <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/internal-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
     </div>
+    </section>
     </main>
     <footer>
         <div class="container">

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -28,6 +28,7 @@
         </div>
     </header>
     <main>
+    <section>
     <p class="works-title">Occlusion (2025)</p>
     <p class="works-details">Duration: 9′30″</p>
     <ul class="instrumentation-list large-margin">
@@ -37,6 +38,7 @@
     <p class="large-margin">Premiere: 23 June 2025, Kunstuniversität Graz</p>
     <hr class="works-separator">
     <p class="italic large-margin">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>
+    </section>
     </main>
     <footer>
         <div class="container">


### PR DESCRIPTION
## Summary
- nest Bodylines accessory instruments inside gear-list
- wrap each work page in a `<section>` so the right-side border appears

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aaef1d980832d9a9251bdea12ebd4