### PR TITLE
Adjust tagline font to match section titles

### DIFF
--- a/style.css
+++ b/style.css
@@ -98,7 +98,7 @@ main {
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
-    font-size: 1em;
+    font-size: 1.6em;
     color: #ffffff;
     font-style: normal;
     font-weight: 300;


### PR DESCRIPTION
## Summary
- enlarge the header tagline so it matches the size of section titles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab2b327dc832d95b7ea1ed639aeb6