### PR TITLE
Fix italic usage in Occlusion notes

### DIFF
--- a/style.css
+++ b/style.css
@@ -139,6 +139,9 @@ p {
 .italic {
     font-style: italic;
 }
+.no-italic {
+    font-style: normal;
+}
 a, .link {
     color: #ffffff;
     font-weight: 400;

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -37,7 +37,7 @@
     </ul>
     <p class="large-margin">Premiere: 23 June 2025, Hermann-Markus-Preßl-Saal, Kunstuniversität Graz, Graz</p>
     <hr class="works-separator">
-    <p class="italic large-margin">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>
+    <p class="italic large-margin"><span class="no-italic">Occlusion</span> is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>
     </section>
     </main>
     <footer>


### PR DESCRIPTION
## Summary
- add `.no-italic` style helper
- keep the rest of the program note in italics, except the word "Occlusion"

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ab641fab0832d803c771af9497544