### PR TITLE
Fix event list indentation

### DIFF
--- a/style.css
+++ b/style.css
@@ -277,14 +277,13 @@ body.about .about-lines {
 
 .events-list {
     list-style-type: none;
-    padding: 0;
+    padding-left: 1em;
     margin: 0;
+    border-left: 3px solid #555555;
 }
 
 .events-list li {
     margin-bottom: 1.5em;
-    padding-left: 1em;
-    border-left: 3px solid #555555;
 }
 
 /* Nested list for program details within events */


### PR DESCRIPTION
## Summary
- adjust CSS for `.events-list` to match second-indent style used in works pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687abb6ac600832da08c06942b4da16f