### PR TITLE
Style adjustments for events bullets and date

### DIFF
--- a/style.css
+++ b/style.css
@@ -303,6 +303,7 @@ body.about .about-lines {
     display: block;
     font-weight: 300;
     margin: 0.2em 0 0 0;
+    color: #bbbbbb;
 }
 
 .event-details {
@@ -312,7 +313,7 @@ body.about .about-lines {
 }
 
 .separator {
-    color: #555555;
+    color: #ffffff;
     padding: 0 0.3em;
 }
 


### PR DESCRIPTION
## Summary
- update event bullets to display in white
- display event date/location text in grey

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687abdf49800832db003f6c768f45c42