### PR TITLE
Fix events page borders

### DIFF
--- a/style.css
+++ b/style.css
@@ -287,13 +287,14 @@ body.about .about-lines {
 
 .events-list {
     list-style-type: none;
-    padding-left: 1em;
+    padding-left: 0;
     margin: 0;
-    border-left: 3px solid #555555;
 }
 
 .events-list li {
     margin-bottom: 1.5em;
+    padding-left: 1em;
+    border-left: 3px solid #555555;
 }
 
 /* Nested list for program details within events */


### PR DESCRIPTION
## Summary
- fix the border styling on the events list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac7d807d8832d957468c8b008e093