### PR TITLE
Fix double line in upcoming events list

### DIFF
--- a/style.css
+++ b/style.css
@@ -302,7 +302,6 @@ body.about .about-lines {
     list-style-type: none;
     padding-left: 1em;
     margin: 0.2em 0 0 0;
-    border-left: 3px solid #555555;
 }
 
 .events-sublist li {


### PR DESCRIPTION
## Summary
- remove the left border from nested event lists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ac8fee6e4832da6891b1490374db4