### PR TITLE
Fix double line in upcoming events list

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -33,10 +33,7 @@
             <ul class="events-list">
                 <li>
                     <span class="event-details"><a href="/projects/reach-touch/" class="link">Reach.Touch.</a></span>
-                    <ul class="events-sublist">
-                        <li><span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a> <span class="separator">&bull;</span> violin: Aleksandra Kornowicz</span></li>
-                        <li><span class="event-details"><a href="/works/assume/" class="link">Assume</a> (W.P.) <span class="separator">&bull;</span> flute: Miho Sakuma, piano: Maria Iaiza, cello: Irati Leoz</span></li>
-                    </ul>
+                    <span class="event-details"><a href="/works/assume/" class="link">Assume</a> (W.P.) <span class="separator">&bull;</span> flute: Miho Sakuma, piano: Maria Iaiza, cello: Irati Leoz; <a href="/works/occlusion/" class="link">Occlusion</a> <span class="separator">&bull;</span> violin: Aleksandra Kornowicz</span>
                     <span class="event-date">28 November 2025, 19:30 <span class="separator">&bull;</span> KULTUM, [imCubus], Graz (AT)</span>
                 </li>
             </ul>

--- a/style.css
+++ b/style.css
@@ -291,7 +291,7 @@ body.about .about-lines {
     margin: 0;
 }
 
-.events-list li {
+.events-list > li {
     margin-bottom: 1.5em;
     padding-left: 1em;
     border-left: 3px solid #555555;
@@ -302,7 +302,6 @@ body.about .about-lines {
     list-style-type: none;
     padding-left: 1em;
     margin: 0.2em 0 0 0;
-    border-left: 3px solid #555555;
 }
 
 .events-sublist li {


### PR DESCRIPTION
## Summary
- keep upcoming events nested items on a single border by applying the border only to first-level list items
- simplify the program listing for Reach.Touch.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ac8fee6e4832da6891b1490374db4