### PR TITLE
Fix event details formatting

### DIFF
--- a/style.css
+++ b/style.css
@@ -306,6 +306,16 @@ body.about .about-lines {
 
 .events-sublist li {
     margin-bottom: 0.2em;
+    display: inline;
+    margin-right: 1em;
+}
+
+.events-sublist li:last-child {
+    margin-right: 0;
+}
+
+.events-sublist .event-details {
+    color: #bbbbbb;
 }
 
 .event-date {


### PR DESCRIPTION
## Summary
- adjust `events-sublist` styles to keep nested pieces on one grey line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687acb71fa34832dbfb9037eb11bd189