### PR TITLE
Revert event indent formatting

### DIFF
--- a/style.css
+++ b/style.css
@@ -306,16 +306,6 @@ body.about .about-lines {
 
 .events-sublist li {
     margin-bottom: 0.2em;
-    display: inline;
-    margin-right: 1em;
-}
-
-.events-sublist li:last-child {
-    margin-right: 0;
-}
-
-.events-sublist .event-details {
-    color: #bbbbbb;
 }
 
 .event-date {


### PR DESCRIPTION
## Summary
- revert the merge commit that changed the event detail formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687acc9b2c08832d80ff6ee8fa93d8d7