### PR TITLE
Fix indent for event pieces

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -34,8 +34,14 @@
                 <li>
                     <span class="event-details"><a href="/projects/reach-touch/" class="link">Reach.Touch.</a></span>
                     <ul class="events-sublist">
-                        <li><span class="event-details"><a href="/works/assume/" class="link">Assume</a> (W.P.) <span class="separator">&bull;</span> flute: Miho Sakuma, piano: Maria Iaiza, cello: Irati Leoz</span></li>
-                        <li><span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a> <span class="separator">&bull;</span> violin: Aleksandra Kornowicz</span></li>
+                        <li>
+                            <span class="event-details"><a href="/works/assume/" class="link">Assume</a> (W.P.)</span>
+                            <span class="event-details event-details-indent"><span class="separator">&bull;</span> flute: Miho Sakuma, piano: Maria Iaiza, cello: Irati Leoz</span>
+                        </li>
+                        <li>
+                            <span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a></span>
+                            <span class="event-details event-details-indent"><span class="separator">&bull;</span> violin: Aleksandra Kornowicz</span>
+                        </li>
                     </ul>
                     <span class="event-date">28 November 2025, 19:30 <span class="separator">&bull;</span> KULTUM, [imCubus], Graz (AT)</span>
                 </li>

--- a/style.css
+++ b/style.css
@@ -320,6 +320,9 @@ body.about .about-lines {
     font-weight: 300;
     margin-top: 0;
 }
+.event-details-indent {
+    padding-left: 1em;
+}
 
 .separator {
     color: #ffffff;


### PR DESCRIPTION
## Summary
- tweak HTML for upcoming events to place instrumentation on a second indented line
- add `.event-details-indent` helper class in stylesheet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b6808026c832daeb805b452d46ec9