### PR TITLE
Fix event listing and update project styles

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -34,8 +34,7 @@
                 <li>
                     <span class="event-details"><a href="/projects/reach-touch/" class="link">Reach.Touch.</a></span>
                     <ul class="events-sublist">
-                        <li><span class="event-details"><a href="/works/assume/" class="link">Assume</a> (W.P.) <span class="separator">&bull;</span> flute: Miho Sakuma, piano: Maria Iaiza, cello: Irati Leoz</span></li>
-                        <li><span class="event-details"><a href="/works/occlusion/" class="link">Occlusion</a> <span class="separator">&bull;</span> violin: Aleksandra Kornowicz</span></li>
+                        <li><span class="event-details"><a href="/works/assume/" class="link">Assume</a> (W.P.), <a href="/works/occlusion/" class="link">Occlusion</a> <span class="separator">&bull;</span> flute: Miho Sakuma, piano: Maria Iaiza, cello: Irati Leoz, violin: Aleksandra Kornowicz</span></li>
                     </ul>
                     <span class="event-date">28 November 2025, 19:30 <span class="separator">&bull;</span> KULTUM, [imCubus], Graz (AT)</span>
                 </li>

--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -33,34 +33,34 @@
     <p class="works-title">Reach.Touch. (2025)</p>
     <p class="works-details italic">with the kind support of <a href="https://www.steiermark.at/" target="_blank" class="link">Land Steiermark</a>, <a href="https://www.oehkug.at/" target="_blank" class="link">ÖH-KUG</a>, and <a href="https://www.kug.ac.at/en/" target="_blank" class="link">Kunstuniversität Graz</a></p>
     <hr class="works-separator">
-    <p>Juan Sarmiento (*2002)</p>
-    <p><span class="italic">Decir adiós</span> (from <span class="italic">Widmung</span>)</p>
+    <p class="regular">Juan Sarmiento (*2002)</p>
+    <p class="regular">Decir adiós (from <span class="italic">Widmung</span>)</p>
     <p class="works-details">for piano and electronics</p>
-    <p><span class="italic">Black bells</span> (from <span class="italic">Widmung</span>)</p>
+    <p class="regular">Black bells (from <span class="italic">Widmung</span>)</p>
     <p class="works-details">for piano</p>
-    <p><span class="italic">[New work]</span> (from <span class="italic">Widmung</span>)</p>
+    <p class="regular">[New work] (from <span class="italic">Widmung</span>)</p>
     <p class="works-details">for piano and electronics</p>
-    <p class="italic">Lindar algo con otro</p>
+    <p class="regular">Lindar algo con otro</p>
     <p class="works-details">for piano</p>
     <hr class="works-separator">
-    <p>Emanuele Savagnone (*1997)</p>
-    <p class="italic">stars on black canvas</p>
+    <p class="regular">Emanuele Savagnone (*1997)</p>
+    <p class="regular">stars on black canvas</p>
     <p class="works-details">for piano</p>
     <hr class="works-separator">
     <p class="works-details">Intermission</p>
     <hr class="works-separator">
-    <p>Leonardo Matteucci (*2000)</p>
-    <p class="italic">Assume</p>
+    <p class="regular">Leonardo Matteucci (*2000)</p>
+    <p class="regular">Assume</p>
     <p class="works-details">for flute, piano, cello and electronics</p>
     <hr class="works-separator">
-    <p>Juan Sarmiento (*2002)</p>
-    <p><span class="italic">Caminos</span> (from <span class="italic">Widmung</span>)</p>
+    <p class="regular">Juan Sarmiento (*2002)</p>
+    <p class="regular">Caminos (from <span class="italic">Widmung</span>)</p>
     <p class="works-details">for electronics</p>
-    <p><span class="italic">Choral</span> (from <span class="italic">Widmung</span>)</p>
+    <p class="regular">Choral (from <span class="italic">Widmung</span>)</p>
     <p class="works-details">for piano and electronics</p>
     <hr class="works-separator">
-    <p>Leonardo Matteucci (*2000)</p>
-    <p class="italic">Occlusion</p>
+    <p class="regular">Leonardo Matteucci (*2000)</p>
+    <p class="regular">Occlusion</p>
     <p class="works-details">for violin and electronics</p>
     <p class="italic large-margin"><span style="font-style: normal;">Reach.Touch.</span> is a concert whose themes focus on hidden bodily mechanics: movements that bend, compress, and collapse.</p>
     <p class="italic large-margin">There are moments when the internal tensions of our bodies escape, manifesting directly through sound—raw emissions tracing the most direct path from interior to exterior, emerging precisely where musical articulation first takes shape. Here, sound reveals a humanity stripped of rhetoric, a bare caress of the body's inner movements.</p>

--- a/style.css
+++ b/style.css
@@ -142,6 +142,9 @@ p {
 .no-italic {
     font-style: normal;
 }
+.regular {
+    font-weight: 400;
+}
 a, .link {
     color: #ffffff;
     font-weight: 400;


### PR DESCRIPTION
## Summary
- show instrumentation for Assume and Occlusion on one line in the upcoming event
- add `.regular` CSS class for normal-weight text
- use `regular` style for composers and compositions in **Reach.Touch.** project page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b749d7dcc832db94b3ce9ba605f72