### PR TITLE
Fix intermission styling

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -47,7 +47,7 @@
     <p class="regular">stars on black canvas</p>
     <p class="works-details">for piano</p>
     <hr class="works-separator">
-    <p class="works-details">Intermission</p>
+    <p class="regular align-center">Intermission</p>
     <hr class="works-separator">
     <p class="regular">Leonardo Matteucci (*2000)</p>
     <p class="regular">Assume</p>

--- a/style.css
+++ b/style.css
@@ -198,6 +198,9 @@ img {
 .align-right {
     text-align: right;
 }
+.align-center {
+    text-align: center;
+}
 .social-icons {
     display: flex;
     gap: 1em;


### PR DESCRIPTION
## Summary
- center align the Intermission text on the Reach.Touch. project page
- add a reusable `.align-center` CSS class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b767ade2c832da7c3f8ba3b6c75fb