### PR TITLE
Set gray color for intermission label

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -47,7 +47,7 @@
     <p class="regular">stars on black canvas</p>
     <p class="works-details">for piano</p>
     <hr class="works-separator">
-    <p class="regular align-center">Intermission</p>
+    <p class="regular align-center gray">Intermission</p>
     <hr class="works-separator">
     <p class="regular">Leonardo Matteucci (*2000)</p>
     <p class="regular">Assume</p>

--- a/style.css
+++ b/style.css
@@ -145,6 +145,9 @@ p {
 .regular {
     font-weight: 400;
 }
+.gray {
+    color: #bbbbbb;
+}
 a, .link {
     color: #ffffff;
     font-weight: 400;


### PR DESCRIPTION
## Summary
- add a `.gray` CSS class
- color the intermission text gray using the new class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b7883194c832d8a0c0a3f6c2551ed