### PR TITLE
Fix double indent line in events

### DIFF
--- a/style.css
+++ b/style.css
@@ -297,7 +297,7 @@ body.about .about-lines {
     margin: 0;
 }
 
-.events-list li {
+.events-list > li {
     margin-bottom: 1.5em;
     padding-left: 1em;
     border-left: 3px solid #555555;
@@ -306,13 +306,14 @@ body.about .about-lines {
 /* Nested list for program details within events */
 .events-sublist {
     list-style-type: none;
-    padding-left: 1em;
+    padding-left: 0;
     margin: 0.2em 0 0 0;
-    border-left: 3px solid #555555;
 }
 
 .events-sublist li {
     margin-bottom: 1.5em;
+    padding-left: 1em;
+    border-left: 3px solid #555555;
 }
 
 .event-date {


### PR DESCRIPTION
## Summary
- fix double line for nested events list by using child selector
- add border to sublist items only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b78eb90c8832da761b439461e72b5