### PR TITLE
Fix events sublist indentation

### DIFF
--- a/style.css
+++ b/style.css
@@ -309,14 +309,14 @@ body.about .about-lines {
 /* Nested list for program details within events */
 .events-sublist {
     list-style-type: none;
-    padding-left: 0;
     margin: 0.2em 0 0 0;
+    padding-left: 1em;
+    border-left: 3px solid #555555;
 }
 
 .events-sublist li {
     margin-bottom: 1.5em;
     padding-left: 1em;
-    border-left: 3px solid #555555;
 }
 
 .event-date {


### PR DESCRIPTION
## Summary
- adjust `.events-sublist` styling so border runs as a single line

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b7a3bfe50832db8245c59778a8ff4