### PR TITLE
Fix spacing before events sublist

### DIFF
--- a/style.css
+++ b/style.css
@@ -312,6 +312,7 @@ body.about .about-lines {
     margin: 0;
     padding-left: 1em;
     border-left: 3px solid #555555;
+    margin-top: 0.2em;
 }
 
 .events-sublist li {


### PR DESCRIPTION
## Summary
- adjust `.events-sublist` margin to even out spacing before the first piece list item

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b7eba2b7c832d8b3530b8a216ef0f