### PR TITLE
Remove YouTube links from past events

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -50,12 +50,10 @@
                 <li>
                     <span class="event-details"><a href="/works/internal/" class="link">Internal</a> (W.P.) <span class="separator">&bull;</span> ensemble: <a href="https://www.opificiosonoro.com/" target="_blank">Opificio Sonoro</a></span>
                     <span class="event-date">11 May 2023, 20:30 <span class="separator">&bull;</span> Festival Orizzonti, Auditorium Santa Cecilia, Perugia (IT)</span>
-                    <a class="button button-thin" href="https://www.youtube.com/watch?v=Bp2AaVuLGsc&list=RDBp2AaVuLGsc&start_radio=1">YouTube</a>
                 </li>
                 <li>
                     <span class="event-details"><a href="/works/a-uno-spirituale-in-firenze/" class="link">A uno spirituale in Firenze</a> (W.P.) <span class="separator">&bull;</span> string quartet: <a href="https://www.quartettomaurice.com/en" target="_blank">Quartetto Maurice</a></span>
                     <span class="event-date">29 October 2021, 20:30 <span class="separator">&bull;</span> Serate Musicali, Turin Conservatory, Turin (IT)</span>
-                    <a class="button button-thin" href="https://www.youtube.com/watch?v=mtePxVfP_Iw">YouTube</a>
                 </li>
             </ul>
         </section>


### PR DESCRIPTION
## Summary
- remove YouTube references from two past events in `events/index.html`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b7f7717dc832d89809eb90249466b