### PR TITLE
Adjust spacing for project text sections

### DIFF
--- a/style.css
+++ b/style.css
@@ -242,6 +242,18 @@ body.about .about-lines {
 .about-text p:first-child {
     margin-top: 0;
 }
+.about-text p {
+    margin: 0;
+}
+.about-text p:not(.works-details):not(:first-child) {
+    margin-top: 0.2em;
+}
+.about-text p.large-margin {
+    margin-bottom: 2.5em;
+}
+.about-text p.mid-margin {
+    margin-bottom: 1.5em;
+}
 .works-list {
     list-style-type: none;
     padding: 0;


### PR DESCRIPTION
## Summary
- fix event list spacing by tweaking `.about-text` paragraphs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b909680d0832d8e5fc8d0fd6193e7