### PR TITLE
Fix Reach.Touch separators

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -11,7 +11,7 @@
         .reach-touch .works-separator {
             width: 50%;
             margin-left: auto;
-            margin-right: auto;
+            margin-right: 0;
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- tweak `.works-separator` style on Reach.Touch so the lines are right aligned

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b963e7430832d8e9221a1aff0b87d