### PR TITLE
Fix sponsorship links color

### DIFF
--- a/style.css
+++ b/style.css
@@ -275,6 +275,12 @@ body.about .about-lines {
     color: #bbbbbb;
     margin-top: 0.2em;
 }
+.works-details a {
+    color: #bbbbbb;
+}
+.works-details a:hover {
+    color: #bbbbbb;
+}
 
 /* List used for the instrumentation of each work */
 .instrumentation-list {


### PR DESCRIPTION
## Summary
- ensure sponsorship text links inside `.works-details` are grey

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b972f8dc8832d9da4802c922a2379