### PR TITLE
Move dedications to replace duration entries

### DIFF
--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -30,6 +30,7 @@
     <main>
     <section>
     <p class="works-title">A uno spirituale in Firenze (2021)</p>
+    <p class="italic">in memoria di Carla Massini</p>
     <p class="works-details">for string quartet and electronics</p>
     <ul class="instrumentation-list">
         <li>Violin I</li>
@@ -38,7 +39,6 @@
         <li>Cello</li>
         <li>Electronics: fixed-media mono electronics &ndash; no amplification needed</li>
     </ul>
-    <p class="italic">in memoria di Carla Massini</p>
     <p class="large-margin">Premiere: 29 October 2021, Serate Musicali, Turin Conservatory, Turin</p>
     <div class="soundcloud-player">
         <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/a-uno-spirituale-in-firenze-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -30,7 +30,7 @@
     <main>
     <section>
     <p class="works-title">Internal (2023)</p>
-    <p class="works-details">Duration: 10′</p>
+    <p class="italic">Commissioned by and dedicated to <a href="https://www.opificiosonoro.com/" target="_blank">Opificio Sonoro</a></p>
     <ul class="instrumentation-list large-margin">
         <li>Flute (with B foot)</li>
         <li>Clarinet in B<img src="../../logos/flat.svg" alt="flat" class="music-icon"></li>
@@ -52,7 +52,6 @@
         <li>Violin</li>
         <li>Cello</li>
     </ul>
-    <p class="italic">Commissioned by and dedicated to <a href="https://www.opificiosonoro.com/" target="_blank">Opificio Sonoro</a></p>
     <p class="large-margin">Premiere: 11 May 2023, Festival Orizzonti, Auditorium Santa Cecilia, Perugia</p>
     <hr class="works-separator">
     <p class="italic large-margin">Establishing a relationship with what we cannot directly interact with: our bodily interior, the joints that emerge from within, contracting, bending, compressing; to better control, anticipate, or even break them, their flexions, and finally stretch them out.</p>


### PR DESCRIPTION
## Summary
- remove duration line from *Internal* and put the dedication text in its place
- move the dedication in *A uno spirituale in Firenze* to the position under the title

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b98795408832da93b1402e84944cc