### PR TITLE
Fix spacing for Reach.Touch. pieces

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -37,11 +37,11 @@
     <div class="about-text">
         <p class="regular">Juan Sarmiento (*2002)</p>
         <p class="regular"><span class="italic">Decir adiós</span> (from <span class="italic">Widmung</span>)</p>
-        <p class="works-details">for piano and electronics</p>
+        <p class="works-details mid-margin">for piano and electronics</p>
         <p class="regular"><span class="italic">Black bells</span> (from <span class="italic">Widmung</span>)</p>
-        <p class="works-details">for piano</p>
+        <p class="works-details mid-margin">for piano</p>
         <p class="regular"><span class="italic">[New work]</span> (from <span class="italic">Widmung</span>)</p>
-        <p class="works-details">for piano and electronics</p>
+        <p class="works-details mid-margin">for piano and electronics</p>
         <p class="regular"><span class="italic">Lindar algo con otro</span></p>
         <p class="works-details">for piano</p>
     </div>
@@ -63,7 +63,7 @@
     <div class="about-text">
         <p class="regular">Juan Sarmiento (*2002)</p>
         <p class="regular"><span class="italic">Caminos</span> (from <span class="italic">Widmung</span>)</p>
-        <p class="works-details">for electronics</p>
+        <p class="works-details mid-margin">for electronics</p>
         <p class="regular"><span class="italic">Choral</span> (from <span class="italic">Widmung</span>)</p>
         <p class="works-details">for piano and electronics</p>
     </div>


### PR DESCRIPTION
## Summary
- space out each piece on the Reach.Touch. project page by using the
  existing `mid-margin` class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bfe277b84832dbbe129614e80dcad