### PR TITLE
Remove Full CV link

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -34,11 +34,6 @@
                 <p class="mid-margin">Born in Perugia, Italy, in 2000, <a href="/">Leonardo Matteucci</a> is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation.</p>
                 <p class="large-margin">He studied in Turin with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> from 2019 to 2021, and in Fermo with <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
             </div>
-            <p class="align-right">
-                <a class="button" href="/lm-CV.pdf" target="_blank">
-                    Full CV <img src="../logos/pdf_file-logo_white.svg" alt="PDF">
-                </a>
-            </p>
         </section>
     </main>
     <footer>


### PR DESCRIPTION
## Summary
- remove the Full CV link block from the about page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e9bf836d4832d9da939a7285d0e37