### PR TITLE
Reorder description in Reach.Touch project page

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -34,6 +34,13 @@
     <p class="works-details italic">with the kind support of <a href="https://www.steiermark.at/" target="_blank" class="link">Land Steiermark</a>, <a href="https://www.oehkug.at/" target="_blank" class="link">ÖH-KUG</a>, and <a href="https://www.kug.ac.at/en/" target="_blank" class="link">Kunstuniversität Graz</a></p>
     <p class="large-margin">Premiere: 28 November 2025, KULTUM, [imCubus], Graz</p>
     <hr class="works-separator">
+    <p class="italic large-margin"><span style="font-style: normal;">Reach.Touch.</span> is a concert whose themes focus on hidden bodily mechanics: movements that bend, compress, and collapse.</p>
+    <p class="italic large-margin">There are moments when the internal tensions of our bodies escape, manifesting directly through sound—raw emissions tracing the most direct path from interior to exterior, emerging precisely where musical articulation first takes shape. Here, sound reveals a humanity stripped of rhetoric, a bare caress of the body's inner movements.</p>
+    <p class="italic large-margin">This visceral intimacy—where touching implies reaching outward—has always represented, to me, an attempt at contact, at correspondence, or at least an affection driven by an urgent need to reach, a commitment to both the musicians' physical gestures and the internal bodily responses of the audience.</p>
+    <p class="italic large-margin">In this context—where musical articulation mirrors a physical gesture reaching outward, straining against its own sonic projection—amplification serves not only as a means to render perceptible what lingers unheard, what merely skims the skin, but also as a medium to empower intimacy. This intimacy communicates most clearly as one draws closer and closer to its source, until it touches the skin.</p>
+    <p class="italic large-margin">Dynamics, therefore, become less about physical intensity and more about unveiling the potency of gesture at its fullest—amplified to clarity without distortion or strain.</p>
+    <p class="italic large-margin">Intimacy demands proximity: listeners must lean in to discern between what is here and what is almost here, between what is touching and what is only attempting to reach. In this delicate space, what is fully present gradually meets what merely shimmers at the edge of perception—where neighboring domains touch without merging.</p>
+    <p class="align-right large-margin" style="font-style: normal;">Leonardo Matteucci</p>
     <div class="about-text">
         <p class="regular">Juan Sarmiento (*2002)</p>
         <p class="regular"><span class="italic">Decir adiós</span> (from <span class="italic">Widmung</span>)</p>
@@ -74,13 +81,6 @@
         <p class="works-details">for violin and electronics</p>
     </div>
     <hr class="works-separator">
-    <p class="italic large-margin"><span style="font-style: normal;">Reach.Touch.</span> is a concert whose themes focus on hidden bodily mechanics: movements that bend, compress, and collapse.</p>
-    <p class="italic large-margin">There are moments when the internal tensions of our bodies escape, manifesting directly through sound—raw emissions tracing the most direct path from interior to exterior, emerging precisely where musical articulation first takes shape. Here, sound reveals a humanity stripped of rhetoric, a bare caress of the body's inner movements.</p>
-    <p class="italic large-margin">This visceral intimacy—where touching implies reaching outward—has always represented, to me, an attempt at contact, at correspondence, or at least an affection driven by an urgent need to reach, a commitment to both the musicians' physical gestures and the internal bodily responses of the audience.</p>
-    <p class="italic large-margin">In this context—where musical articulation mirrors a physical gesture reaching outward, straining against its own sonic projection—amplification serves not only as a means to render perceptible what lingers unheard, what merely skims the skin, but also as a medium to empower intimacy. This intimacy communicates most clearly as one draws closer and closer to its source, until it touches the skin.</p>
-    <p class="italic large-margin">Dynamics, therefore, become less about physical intensity and more about unveiling the potency of gesture at its fullest—amplified to clarity without distortion or strain.</p>
-    <p class="italic large-margin">Intimacy demands proximity: listeners must lean in to discern between what is here and what is almost here, between what is touching and what is only attempting to reach. In this delicate space, what is fully present gradually meets what merely shimmers at the edge of perception—where neighboring domains touch without merging.</p>
-    <p class="align-right large-margin" style="font-style: normal;">Leonardo Matteucci</p>
     <div class="supporter-logos">
         <img src="../../logos/land_steiermark-logo_white.svg" alt="Land Steiermark">
         <img src="../../logos/öh_kug-logo.png" alt="ÖH-KUG">


### PR DESCRIPTION
## Summary
- rearrange text on the Reach.Touch. page to show the description before the program order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e9ff1031c832da96258661d699327