### PR TITLE
Add duration detail to Reach.Touch project page

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -32,6 +32,7 @@
 <section class="reach-touch">
     <p class="works-title">Reach.Touch. (2025)</p>
     <p class="works-details italic">with the kind support of <a href="https://www.steiermark.at/" target="_blank" class="link">Land Steiermark</a>, <a href="https://www.oehkug.at/" target="_blank" class="link">ÖH-KUG</a>, and <a href="https://www.kug.ac.at/en/" target="_blank" class="link">Kunstuniversität Graz</a></p>
+    <p class="works-details">Duration: 1h10′</p>
     <p class="large-margin">Premiere: 28 November 2025, KULTUM, [imCubus], Graz</p>
     <hr class="works-separator">
     <p class="italic large-margin"><span style="font-style: normal;">Reach.Touch.</span> is a concert project whose themes focus on hidden bodily mechanics: movements that bend, compress, and collapse.</p>


### PR DESCRIPTION
## Summary
- add a duration line after the supporters line on the Reach.Touch project page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ea58691cc832d8f40ab802a78e06f