### PR TITLE
Update reach-touch page layout

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -59,9 +59,9 @@
         <p class="regular"><span class="italic">stars on black canvas</span></p>
         <p class="works-details">for piano</p>
     </div>
-    <hr class="works-separator">
-    <p class="regular align-right gray"><span class="italic">INTERMISSION</span></p>
-    <hr class="works-separator">
+    <hr class="works-separator-small">
+    <p class="regular align-right gray intermission-text"><span class="italic">INTERMISSION</span></p>
+    <hr class="works-separator-small">
     <div class="about-text">
         <p class="regular">Leonardo Matteucci (*2000)</p>
         <p class="regular"><span class="italic"><a href="/works/assume/" class="link">Assume</a></span></p>
@@ -81,11 +81,7 @@
         <p class="regular"><span class="italic"><a href="/works/occlusion/" class="link">Occlusion</a></span></p>
         <p class="works-details">for violin and electronics</p>
     </div>
-    <hr class="works-separator">
-    <div class="supporter-logos">
-        <img src="../../logos/land_steiermark-logo_white.svg" alt="Land Steiermark">
-        <img src="../../logos/öh_kug-logo.png" alt="ÖH-KUG">
-    </div>
+    
     </section>
     </main>
     <footer>

--- a/style.css
+++ b/style.css
@@ -382,6 +382,17 @@ body.about .about-lines {
     margin-right: auto;
 }
 
+/* Reduced margin separators used around the intermission marker */
+.works-separator-small {
+    border: 0;
+    border-top: 1px solid #555555;
+    margin: 0.5em 0;
+}
+
+.intermission-text {
+    margin: 0.5em 0;
+}
+
 .hero h1 {
     font-size: 2em;
 }


### PR DESCRIPTION
## Summary
- shrink space around "INTERMISSION" text
- remove support logos from `reach-touch` page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687eaae00dd8832d85677fa886d78eae