### PR TITLE
Fix dedication style on A uno spirituale page

### DIFF
--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -30,7 +30,8 @@
     <main>
     <section>
     <p class="works-title">A uno spirituale in Firenze (2021)</p>
-    <p class="italic">in memoria di Carla Massini</p>
+    <p class="works-details italic">in memoria di Carla Massini</p>
+    <p class="works-details" style="color: #ffffff; margin-bottom: 0;">Duration: 5′</p>
     <p class="works-details">for string quartet and electronics</p>
     <ul class="instrumentation-list">
         <li>Violin I</li>


### PR DESCRIPTION
## Summary
- style dedication for *A uno spirituale in Firenze* as gray works-details
- add duration information beneath the dedication

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eabd08550832da24a9915205a8bc2