### PR TITLE
Remove redundant separator before intermission

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -59,7 +59,6 @@
         <p class="regular"><span class="italic">stars on black canvas</span></p>
         <p class="works-details">for piano</p>
     </div>
-    <hr class="works-separator-small">
     <p class="regular align-right gray intermission-text"><span class="italic">INTERMISSION</span></p>
     <hr class="works-separator-small">
     <div class="about-text">


### PR DESCRIPTION
## Summary
- delete the extra `<hr>` line above the Intermission marker in the reach-touch project page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eaee4af9c832d872e4be326fc6c48