### PR TITLE
Fix tagline hover underline

### DIFF
--- a/style.css
+++ b/style.css
@@ -104,6 +104,9 @@ main {
     font-style: normal;
     font-weight: 300;
 }
+.tagline:hover {
+    text-decoration: none;
+}
 nav a {
     margin-left: 1.5em;
     font-weight: 400;


### PR DESCRIPTION
## Summary
- avoid underline effect on the tagline when hovered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eaf2d97dc832dab5ac76b28c5bb3e