### PR TITLE
Update separator color in event dates

### DIFF
--- a/style.css
+++ b/style.css
@@ -363,6 +363,11 @@ body.about .about-lines {
     padding: 0 0.3em;
 }
 
+/* Separator inside event date should match the surrounding text color */
+.event-date .separator {
+    color: inherit;
+}
+
 .events-separator {
     border: 0;
     border-top: 1px solid #555555;


### PR DESCRIPTION
## Summary
- ensure the bullet separator next to event dates inherits the grey text colour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb259ddd8832da7c9120954da8a07