### PR TITLE
Fix menu padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -457,6 +457,7 @@ body.about .about-lines {
         margin-top: 0.5em;
         overflow: hidden;
         gap: 0.5em;
+        padding: 1em;
         max-height: 0;
         opacity: 0;
         transform: translateY(-10px);


### PR DESCRIPTION
## Summary
- expand mobile nav panel padding so underline animation shows on last link

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ebd9cb294832da55c6db831bb87b5