### PR TITLE
Add placeholder images for home and about

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -34,6 +34,7 @@
                 <p class="mid-margin"><a href="/">Leonardo Matteucci</a> is a composer exploring inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation.</p>
                 <p class="large-margin">He studied composition with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> in Turin (2019–2021) and <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> in Fermo (2021–2023), and is currently pursuing a Master’s degree under Franck Bedrossian at the <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
             </div>
+            <img src="../graphics/placeholder.svg" alt="Placeholder image">
         </section>
     </main>
     <footer>

--- a/graphics/placeholder.svg
+++ b/graphics/placeholder.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080">
+  <rect width="100%" height="100%" fill="#888" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
 
     <main>
         <section class="hero">
-            <img src="/graphics/RT-image-2.1.png" alt="Home graphic">
+            <img src="/graphics/placeholder.svg" alt="Placeholder image">
         </section>
     </main>
     <footer>


### PR DESCRIPTION
## Summary
- replace the home page hero image with a gray placeholder
- insert a gray placeholder image at the end of the about text
- include the new SVG placeholder graphic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ec019ac54832db0f83629b0997d5b