### PR TITLE
Add full-width placeholders

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -34,7 +34,7 @@
                 <p class="mid-margin"><a href="/">Leonardo Matteucci</a> is a composer exploring inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation.</p>
                 <p class="large-margin">He studied composition with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> in Turin (2019–2021) and <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> in Fermo (2021–2023), and is currently pursuing a Master’s degree under Franck Bedrossian at the <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
             </div>
-            <img src="../graphics/placeholder.svg" alt="Placeholder image">
+            <img src="../graphics/placeholder.svg" alt="Placeholder image" class="placeholder-image">
         </section>
     </main>
     <footer>

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
 
     <main>
         <section class="hero">
-            <img src="/graphics/placeholder.svg" alt="Placeholder image">
+            <img src="/graphics/placeholder.svg" alt="Placeholder image" class="placeholder-image">
         </section>
     </main>
     <footer>

--- a/style.css
+++ b/style.css
@@ -203,6 +203,12 @@ img {
     margin-left: auto;
     margin-right: auto;
 }
+.placeholder-image {
+    width: 100%;
+    height: auto;
+    margin-left: 0;
+    margin-right: 0;
+}
 .logo img,
 .footer-icons img {
     margin-top: 0;


### PR DESCRIPTION
## Summary
- add `.placeholder-image` CSS helper to keep placeholder images inside page margins
- use the helper for hero and about images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f57bea634832d81c038e74459c76c