### PR TITLE
Fix hero image height

### DIFF
--- a/style.css
+++ b/style.css
@@ -264,6 +264,12 @@ section {
     padding-right: 1em;
 }
 
+.hero {
+    margin: 0;
+    border-right: none;
+    padding-right: 0;
+}
+
 body.about .about-lines {
     margin-top: 0;
 }
@@ -439,9 +445,9 @@ body.about .about-lines {
 
 .hero img {
     width: 100%;
-    height: auto;
-    max-height: 100vh;
-    object-fit: contain;
+    height: calc(100vh - 118px - 120px);
+    max-height: none;
+    object-fit: cover;
 }
 
 


### PR DESCRIPTION
## Summary
- ensure hero section has no extra margin and border
- extend hero image to fill space between header and footer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f5a243d8c832db377a07d06b7e813