### PR TITLE
Remove instrumentation note from A uno spirituale in Firenze page

### DIFF
--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -32,7 +32,6 @@
     <p class="works-title">A uno spirituale in Firenze (2021)</p>
     <p class="works-details italic">in memoria di Carla Massini</p>
     <p class="works-details" style="color: #ffffff; margin-bottom: 0;">Duration: 5′</p>
-    <p class="works-details">for string quartet and electronics</p>
     <ul class="instrumentation-list">
         <li>Violin I</li>
         <li>Violin II</li>


### PR DESCRIPTION
## Summary
- remove 'for string quartet and electronics' from the *A uno spirituale in Firenze* work page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f5e54f380832d8587165556a4d9e5