### PR TITLE
Remove italics from piece names in Reach.Touch

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -48,40 +48,40 @@
     <p class="align-right" style="font-style: normal;">Leonardo Matteucci</p>
     <div class="about-text">
         <p class="regular">Juan Sarmiento (*2002)</p>
-        <p class="regular"><span class="italic">Decir adiós</span> (from <span class="italic">Widmung</span>)</p>
+        <p class="regular">Decir adiós (from <span class="italic">Widmung</span>)</p>
         <p class="works-details italic mid-margin">for piano and electronics</p>
-        <p class="regular"><span class="italic">Black bells</span> (from <span class="italic">Widmung</span>)</p>
+        <p class="regular">Black bells (from <span class="italic">Widmung</span>)</p>
         <p class="works-details italic mid-margin">for piano</p>
-        <p class="regular"><span class="italic">[New work]</span> (from <span class="italic">Widmung</span>)</p>
+        <p class="regular">[New work] (from <span class="italic">Widmung</span>)</p>
         <p class="works-details italic mid-margin">for piano and electronics</p>
-        <p class="regular"><span class="italic">Lindar algo con otro</span></p>
+        <p class="regular">Lindar algo con otro</p>
         <p class="works-details italic">for piano</p>
     </div>
     <hr class="works-separator-half">
     <div class="about-text">
         <p class="regular">Emanuele Savagnone (*1997)</p>
-        <p class="regular"><span class="italic">stars on black canvas</span></p>
+        <p class="regular">stars on black canvas</p>
         <p class="works-details italic">for piano</p>
     </div>
     <p class="regular align-right gray intermission-text"><span class="italic">INTERMISSION</span></p>
     <hr class="works-separator-small">
     <div class="about-text">
         <p class="regular">Leonardo Matteucci (*2000)</p>
-        <p class="regular"><span class="italic"><a href="/works/assume/" class="link">Assume</a></span></p>
+        <p class="regular"><a href="/works/assume/" class="link">Assume</a></p>
         <p class="works-details italic">for flute, piano, cello and electronics</p>
     </div>
     <hr class="works-separator-half">
     <div class="about-text">
         <p class="regular">Juan Sarmiento (*2002)</p>
-        <p class="regular"><span class="italic">Caminos</span> (from <span class="italic">Widmung</span>)</p>
+        <p class="regular">Caminos (from <span class="italic">Widmung</span>)</p>
         <p class="works-details italic mid-margin">for electronics</p>
-        <p class="regular"><span class="italic">Choral</span> (from <span class="italic">Widmung</span>)</p>
+        <p class="regular">Choral (from <span class="italic">Widmung</span>)</p>
         <p class="works-details italic">for piano and electronics</p>
     </div>
     <hr class="works-separator-half">
     <div class="about-text">
         <p class="regular">Leonardo Matteucci (*2000)</p>
-        <p class="regular"><span class="italic"><a href="/works/occlusion/" class="link">Occlusion</a></span></p>
+        <p class="regular"><a href="/works/occlusion/" class="link">Occlusion</a></p>
         <p class="works-details italic">for violin and electronics</p>
     </div>
     


### PR DESCRIPTION
## Summary
- update the Reach.Touch project page to keep piece names in normal style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f639699f8832dbb2bf093118bd910