### PR TITLE
Fix spacing around works separators

### DIFF
--- a/style.css
+++ b/style.css
@@ -417,7 +417,7 @@ body.about .about-lines {
 .works-separator {
     border: 0;
     border-top: 1px solid #555555;
-    margin: 2em 0;
+    margin: 1em 0;
 }
 
 /* Half-length separator used on specific project pages */

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -41,7 +41,7 @@
             <span class="works-details italic">no instrumental amplification required</span>
         </li>
     </ul>
-    <p class="large-margin">Premiere: 29 October 2021, Serate Musicali, Turin Conservatory, Turin</p>
+    <p>Premiere: 29 October 2021, Serate Musicali, Turin Conservatory, Turin</p>
     <hr class="works-separator">
     <div class="soundcloud-player">
         <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/a-uno-spirituale-in-firenze-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -44,7 +44,7 @@
             </ul>
         </li>
     </ul>
-    <p class="large-margin">Premiere: 28 November 2025, KULTUM, [imCubus], Graz</p>
+    <p>Premiere: 28 November 2025, KULTUM, [imCubus], Graz</p>
     <hr class="works-separator">
     </section>
     </main>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -54,7 +54,7 @@
         </li>
     </ul>
     <hr class="works-separator">
-    <p class="italic large-margin">A transformed body needs a new representation: what persists are the lines in its movements; there is no musical semantics, only the need to move, to breathe within it.</p>
+    <p class="italic">A transformed body needs a new representation: what persists are the lines in its movements; there is no musical semantics, only the need to move, to breathe within it.</p>
     <div class="soundcloud-player">
         <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/bodylines-home-studio-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
     </div>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -53,9 +53,9 @@
         <li>Violin</li>
         <li>Cello</li>
     </ul>
-    <p class="large-margin">Premiere: 11 May 2023, Festival Orizzonti, Auditorium Santa Cecilia, Perugia</p>
+    <p>Premiere: 11 May 2023, Festival Orizzonti, Auditorium Santa Cecilia, Perugia</p>
     <hr class="works-separator">
-    <p class="italic large-margin">Establishing a relationship with what we cannot directly interact with: our bodily interior, the joints that emerge from within, contracting, bending, compressing; to better control, anticipate, or even break them, their flexions, and finally stretch them out.</p>
+    <p class="italic">Establishing a relationship with what we cannot directly interact with: our bodily interior, the joints that emerge from within, contracting, bending, compressing; to better control, anticipate, or even break them, their flexions, and finally stretch them out.</p>
     <div class="soundcloud-player">
         <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/internal-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
     </div>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -40,9 +40,9 @@
             </ul>
         </li>
     </ul>
-    <p class="large-margin">Premiere: 23 June 2025, Hermann-Markus-Preßl-Saal, Kunstuniversität Graz, Graz</p>
+    <p>Premiere: 23 June 2025, Hermann-Markus-Preßl-Saal, Kunstuniversität Graz, Graz</p>
     <hr class="works-separator">
-    <p class="italic large-margin"><span class="no-italic">Occlusion</span> is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>
+    <p class="italic"><span class="no-italic">Occlusion</span> is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>
     </section>
     </main>
     <footer>


### PR DESCRIPTION
## Summary
- ensure paragraphs around works separators use default spacing
- use a smaller margin on `.works-separator`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6a2f1380832d83b19da2b21b37ba