### PR TITLE
Improve music icon spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -235,7 +235,11 @@ img {
     width: 1em;
     height: 1em;
     display: inline-block;
-    vertical-align: middle;
+    /* Align musical accidentals with the surrounding text */
+    vertical-align: -0.15em;
+    /* Tighten spacing between accidentals and adjacent text */
+    margin-left: -0.1em;
+    margin-right: -0.1em;
 }
 
 .align-right {


### PR DESCRIPTION
## Summary
- fine-tune `.music-icon` rules so sharp and flat symbols sit closer to adjacent letters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f82216e58832dae166a850d388587