### PR TITLE
Fix bottom spacing before footer

### DIFF
--- a/style.css
+++ b/style.css
@@ -92,6 +92,7 @@ header .container {
 }
 main {
     margin-top: var(--header-height);
+    margin-bottom: 1em;
     max-width: 700px;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
## Summary
- set a margin on `<main>` so the last item always sits one paragraph space above the footer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8378e78c832da3a0a9fdd7b538e1