### PR TITLE
Fix styling for Dehiscence subtitle

### DIFF
--- a/style.css
+++ b/style.css
@@ -344,6 +344,11 @@ body.about .about-lines {
     color: #bbbbbb;
 }
 
+/* Separator inside works details should match the surrounding text color */
+.works-details .separator {
+    color: inherit;
+}
+
 /* List used for the instrumentation of each work */
 .instrumentation-list {
     list-style-type: none;

--- a/works/index.html
+++ b/works/index.html
@@ -33,7 +33,7 @@
             <ul class="works-list">
                 <li>
                     <span class="works-title">Dehiscence (2026)</span>
-                    <span class="works-details italic">for ensemble and electronics <span class="separator">&bull;</span> Upcoming</span>
+                    <span class="works-details italic">for ensemble and electronics <span class="separator">&bull;</span> <span class="no-italic">Upcoming</span></span>
                 </li>
             </ul>
             <hr class="works-separator">


### PR DESCRIPTION
## Summary
- keep "Upcoming" non-italic on Works page
- ensure separator bullet in works list matches text color

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8bb876ec832da0c5fbb03780e910