### PR TITLE
Add blank dedication placeholders in works pages

### DIFF
--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -30,6 +30,7 @@
     <main>
     <section>
     <p class="works-title">Assume (2025)</p>
+    <p class="works-details italic"></p>
     <p class="works-details" style="color: #ffffff;">Duration: 15′</p>
     <ul class="instrumentation-list large-margin">
         <li>Flute</li>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -30,6 +30,7 @@
     <main>
     <section>
     <p class="works-title">Bodylines (2023)</p>
+    <p class="works-details italic"></p>
     <p class="works-details" style="color: #ffffff;">Duration: 7′30″</p>
     <ul class="instrumentation-list large-margin">
         <li>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -30,6 +30,7 @@
     <main>
     <section>
     <p class="works-title">Occlusion (2025)</p>
+    <p class="works-details italic"></p>
     <p class="works-details" style="color: #ffffff;">Duration: 9′30″</p>
     <ul class="instrumentation-list large-margin">
         <li>Violin</li>


### PR DESCRIPTION
## Summary
- ensure Works page layout always keeps a blank dedication line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8eb83578832da4c6f533690bcd82