### PR TITLE
Reduce spacing between AUSIF text and translation

### DIFF
--- a/style.css
+++ b/style.css
@@ -151,6 +151,11 @@ p {
 .no-italic {
     font-style: normal;
 }
+
+/* Reduce spacing between original Italian text and its translation */
+p.italic + p.no-italic {
+    margin-top: -0.5em;
+}
 .regular {
     font-weight: 400;
 }


### PR DESCRIPTION
## Summary
- adjust style for translation paragraphs so English text sits closer to the Italian original

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa63161f0832db3f6977ddc4e27b2