### PR TITLE
Tighter translation paragraphs

### DIFF
--- a/style.css
+++ b/style.css
@@ -152,9 +152,12 @@ p {
     font-style: normal;
 }
 
-/* Reduce spacing between original Italian text and its translation */
-p.italic + p.no-italic {
-    margin-top: -0.5em;
+/* Zero out space between aligned translation lines */
+.translation-ita {
+    margin-bottom: 0;
+}
+.translation-eng {
+    margin-top: 0;
 }
 .regular {
     font-weight: 400;

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -44,16 +44,16 @@
     <p>Premiere: 29 October 2021, Serate Musicali, Turin Conservatory, Turin</p>
     <hr class="works-separator">
     <p class="italic">Five aphorisms inspired by an excerpt from the homonymous letter by Saint Catherine of Siena, addressed "to a devotee who was scandalized by her abstinences." This letter is taken from the second volume of a collection edited by Niccolò Tommaseo and published in Florence in 1860 by G. Barbèra.</p>
-    <p class="italic"><span class="no-italic regular">1</span> «[...] e prego Dio e pregherò, che mi dia grazia che in quest’atto del mangiare io viva come le altre creature [...]»</p>
-    <p class="no-italic">"[...] and I pray and will continue to pray to God to grant me the grace to live, in this act of eating, as other creatures do [...]"</p>
-    <p class="italic"><span class="no-italic regular">2</span> «[...] e Dio che per singolarissima grazia m’abbia fatto correggere il vizio della gola [...]»</p>
-    <p class="no-italic">"[...] and God who, through a most singular grace, has allowed me to correct the vice of gluttony [...]"</p>
-    <p class="italic"><span class="no-italic regular">3a</span> «[...] Io per me non so che altro rimedio ponermici, … se non ch’io prego voi che preghiate quella somma eterna Verità …»</p>
-    <p class="no-italic">"[...] As for myself, I do not know what other remedy I can apply, except to ask you to pray to that supreme eternal Truth [...]"</p>
-    <p class="italic"><span class="no-italic regular">4</span> «E io son certa, che la bontà di Dio non spregierà le vostre orazioni. [...]»</p>
-    <p class="no-italic">"And I am certain that the goodness of God will not despise your prayers. [...]"</p>
-    <p class="italic"><span class="no-italic regular">3b (5)</span> «[...] che mi dia grazia, [...] che mi faccia prendere il cibo, se gli piace.»</p>
-    <p class="no-italic">"[...] that He may grant me the grace [...] to partake of food, if it pleases Him."</p>
+    <p class="italic translation-ita"><span class="no-italic regular">1</span> «[...] e prego Dio e pregherò, che mi dia grazia che in quest’atto del mangiare io viva come le altre creature [...]»</p>
+    <p class="no-italic translation-eng">"[...] and I pray and will continue to pray to God to grant me the grace to live, in this act of eating, as other creatures do [...]"</p>
+    <p class="italic translation-ita"><span class="no-italic regular">2</span> «[...] e Dio che per singolarissima grazia m’abbia fatto correggere il vizio della gola [...]»</p>
+    <p class="no-italic translation-eng">"[...] and God who, through a most singular grace, has allowed me to correct the vice of gluttony [...]"</p>
+    <p class="italic translation-ita"><span class="no-italic regular">3a</span> «[...] Io per me non so che altro rimedio ponermici, … se non ch’io prego voi che preghiate quella somma eterna Verità …»</p>
+    <p class="no-italic translation-eng">"[...] As for myself, I do not know what other remedy I can apply, except to ask you to pray to that supreme eternal Truth [...]"</p>
+    <p class="italic translation-ita"><span class="no-italic regular">4</span> «E io son certa, che la bontà di Dio non spregierà le vostre orazioni. [...]»</p>
+    <p class="no-italic translation-eng">"And I am certain that the goodness of God will not despise your prayers. [...]"</p>
+    <p class="italic translation-ita"><span class="no-italic regular">3b (5)</span> «[...] che mi dia grazia, [...] che mi faccia prendere il cibo, se gli piace.»</p>
+    <p class="no-italic translation-eng">"[...] that He may grant me the grace [...] to partake of food, if it pleases Him."</p>
     <div class="soundcloud-player">
         <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/a-uno-spirituale-in-firenze-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
     </div>


### PR DESCRIPTION
## Summary
- add CSS classes for zero spacing between Italian text and translation
- apply the new classes to the translation pairs in A uno spirituale in Firenze

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa737ad14832d90c73e89b1c72b06