### PR TITLE
Fix citation markup in spirituale text

### DIFF
--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -52,7 +52,7 @@
     <p class="no-italic translation-eng gray">"[…] As for myself, I do not know what other remedy I can apply, except to ask you to pray to that supreme eternal Truth […]"</p>
     <p class="italic translation-ita"><span class="no-italic regular">4</span> «E io son certa, che la bontà di Dio non spregierà le vostre orazioni.»</p>
     <p class="no-italic translation-eng gray">"And I am certain that the goodness of God will not despise your prayers."</p>
-    <p class="italic translation-ita"><span class="no-italic regular">3b (5)</span> «[…] che mi dia grazia, […] che mi faccia prendere il cibo, se gli piace.»</p>
+    <p class="italic translation-ita"><span class="no-italic regular">3b</span> «[…] che mi dia grazia, […] che mi faccia prendere il cibo, se gli piace.»</p>
     <p class="no-italic translation-eng gray final">"[…] that He may grant me the grace […] to partake of food, if it pleases Him."</p>
     <div class="soundcloud-player">
         <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/a-uno-spirituale-in-firenze-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>


### PR DESCRIPTION
## Summary
- fix markup around section label for the Italian passage in **A uno spirituale in Firenze**

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fed089304832daf8481c877e1fe69