### PR TITLE
Make optional italic on Internal page

### DIFF
--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -53,7 +53,7 @@
         <li>Violin</li>
         <li>Cello</li>
         <li>
-            Electronics (optional): fixed media (mono)
+            Electronics (<span class="italic">optional</span>): fixed media (mono)
             <ul class="gear-list">
                 <li>1 audio exciter</li>
             </ul>


### PR DESCRIPTION
## Summary
- style the word "optional" as italic on the Internal work page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fed47e69c832da6f1c96a2e1cf40e