### PR TITLE
Fix Assume instrumentation order

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -68,7 +68,7 @@
     <div class="about-text">
         <p class="regular">Leonardo Matteucci (*2000)</p>
         <p class="regular"><a href="/works/assume/" class="link">Assume</a></p>
-        <p class="works-details italic">for flute, piano, cello and electronics</p>
+        <p class="works-details italic">for piano, flute, cello and electronics</p>
     </div>
     <hr class="works-separator-half">
     <div class="about-text">

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -33,8 +33,8 @@
     <p class="works-details italic"></p>
     <p class="works-details" style="color: #ffffff;">Duration: 15′</p>
     <ul class="instrumentation-list large-margin">
-        <li>Flute</li>
         <li>Piano</li>
+        <li>Flute</li>
         <li>Cello</li>
         <li>
             Electronics: fixed media (5-channel)

--- a/works/index.html
+++ b/works/index.html
@@ -44,7 +44,7 @@
                 </li>
                 <li>
                     <span class="works-title"><a href="/works/assume/" class="link">Assume</a> (2025)</span>
-                    <span class="works-details italic">for flute, piano, cello and electronics</span>
+                    <span class="works-details italic">for piano, flute, cello and electronics</span>
                 </li>
                 <li>
                     <span class="works-title"><a href="/works/bodylines/" class="link">Bodylines</a> (2023)</span>


### PR DESCRIPTION
## Summary
- reorder instruments for *Assume*
- update phrase "for flute, piano, cello and electronics" to "for piano, flute, cello and electronics"

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ff0800840832d845bd21239d16aad