### PR TITLE
Fix Internal instrumentation optional style

### DIFF
--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -53,7 +53,7 @@
         <li>Violin</li>
         <li>Cello</li>
         <li>
-            Electronics (<span class="italic">optional</span>): fixed media (mono)
+            Electronics <span class="italic">(optional)</span>: fixed media (mono)
             <ul class="gear-list">
                 <li>1 audio exciter</li>
             </ul>


### PR DESCRIPTION
## Summary
- fix the styling of `(optional)` in Internal instrumentation list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ff0de6490832d968ecc1e07b9114c