### PR TITLE
Fix instrumentation text formatting

### DIFF
--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -53,7 +53,7 @@
         <li>Violin</li>
         <li>Cello</li>
         <li>
-            Electronics <span class="italic">(optional)</span>: fixed media (mono)
+            Electronics (optional): fixed media (mono)
             <ul class="gear-list">
                 <li>1 audio exciter</li>
             </ul>


### PR DESCRIPTION
## Summary
- remove italic span from optional electronics description

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ff2e776e4832dac1d151ac71c3a88