### PR TITLE
Fix percussion sublist spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -389,6 +389,15 @@ body.about .about-lines {
     margin-bottom: 0.2em;
 }
 
+/* Variant with tighter spacing for specific lists */
+.gear-list-tight {
+    margin-top: 0;
+}
+
+.gear-list-tight li {
+    margin-bottom: 0;
+}
+
 .soundcloud-player {
     margin: 1em 0;
 }

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -37,7 +37,7 @@
         <li>Clarinet in B<img src="../../logos/flat.svg" alt="flat" class="music-icon"></li>
         <li>
             Percussion
-            <ul class="gear-list">
+            <ul class="gear-list gear-list-tight">
                 <li>Vibraphone</li>
                 <li>Crotales (F<img src="../../logos/sharp.svg" alt="sharp" class="music-icon"><sup>6</sup>,&nbsp;G<img src="../../logos/sharp.svg" alt="sharp" class="music-icon"><sup>6</sup>,&nbsp;A<sup>6</sup>,&nbsp;B<sup>6</sup>)</li>
             </ul>


### PR DESCRIPTION
## Summary
- add new `.gear-list-tight` style for reduced spacing
- use the tighter spacing for the Internal percussion list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff27763a0832d89d40c8f4925f90d