### PR TITLE
Fix instrumentation spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -391,12 +391,12 @@ body.about .about-lines {
 
 /* Variant with tighter spacing for specific lists */
 .gear-list-tight {
-    margin-top: 0;
+    margin-top: 0.2em;
 }
 
 .gear-list-tight li {
     margin-bottom: 0;
-    line-height: 1.3;
+    line-height: 1.1;
 }
 
 .soundcloud-player {


### PR DESCRIPTION
## Summary
- tweak spacing for tight gear lists so sub-items don't crowd

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff5e80014832dab3737046c01f0e6