### PR TITLE
Fix right-to-left header nav layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -187,8 +187,7 @@ header nav {
     display: flex;
     gap: 1em;
     align-items: center;
-    justify-content: flex-end;
-    width: 100%;
+    flex-direction: row-reverse;
 }
 header nav a {
     position: relative;


### PR DESCRIPTION
## Summary
- remove full-width right alignment from header nav
- display navigation items in reverse order so they read right-to-left

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ff6aa339c832d84c2948d88c0e554