### PR TITLE
Fix instrument list spacing in 'Internal' page

### DIFF
--- a/style.css
+++ b/style.css
@@ -393,6 +393,7 @@ body.about .about-lines {
 /* Variant with tighter spacing for specific lists */
 .gear-list-tight {
     margin-top: 0.2em;
+    margin-bottom: 0.5em;
 }
 
 .gear-list-tight li {


### PR DESCRIPTION
## Summary
- add bottom margin to `.gear-list-tight` so spacing after Crotales matches other instruments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff7ad168c832d96c9877a9baa75a8