### PR TITLE
Fix percussion list spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -391,9 +391,10 @@ body.about .about-lines {
 }
 
 /* Variant with tighter spacing for specific lists */
+
 .gear-list-tight {
     margin-top: 0.2em;
-    margin-bottom: 0.5em;
+    margin-bottom: 0;
 }
 
 .gear-list-tight li {

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -37,7 +37,7 @@
         <li>Clarinet in B<img src="../../logos/flat.svg" alt="flat" class="music-icon"></li>
         <li>
             Percussion
-            <ul class="gear-list">
+            <ul class="gear-list gear-list-tight">
                 <li>Vibraphone</li>
                 <li>Crotales (F<img src="../../logos/sharp.svg" alt="sharp" class="music-icon"><sup>6</sup>,&nbsp;G<img src="../../logos/sharp.svg" alt="sharp" class="music-icon"><sup>6</sup>,&nbsp;A<sup>6</sup>,&nbsp;B<sup>6</sup>)</li>
             </ul>


### PR DESCRIPTION
## Summary
- use `gear-list-tight` for percussion list
- update list margin rule so bottom spacing matches other instruments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ffa462be4832d827aaaed25e44312