### PR TITLE
Reduce menu gap

### DIFF
--- a/style.css
+++ b/style.css
@@ -185,7 +185,7 @@ header nav a:hover {
 header nav {
     margin-left: auto;
     display: flex;
-    gap: 0.5em;
+    gap: 0.25em;
     align-items: flex-end;
     flex-direction: column;
 }


### PR DESCRIPTION
## Summary
- tighten header navigation spacing by reducing the gap to `0.25em`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ffc071db8832db1c2272e5f438ea6