### PR TITLE
Fix percussion sublist spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -398,8 +398,8 @@ body.about .about-lines {
 }
 
 .gear-list-tight li {
-    margin-bottom: 0;
-    line-height: 1.1;
+    margin-bottom: 0.2em;
+    line-height: 1.6;
 }
 
 .soundcloud-player {


### PR DESCRIPTION
## Summary
- ensure `gear-list-tight` matches `gear-list` spacing so percussion items line up with piano section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ffca18354832dabb37626b50fc469