### PR TITLE
Fix octave formatting in Internal instrumentation

### DIFF
--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -39,7 +39,7 @@
             Percussion
             <ul class="gear-list gear-list-tight">
                 <li>Vibraphone</li>
-                <li>Crotales (F<img src="../../logos/sharp.svg" alt="sharp" class="music-icon"><sup>6</sup>,&nbsp;G<img src="../../logos/sharp.svg" alt="sharp" class="music-icon"><sup>6</sup>,&nbsp;A<sup>6</sup>,&nbsp;B<sup>6</sup>)</li>
+                <li>Crotales (F<img src="../../logos/sharp.svg" alt="sharp" class="music-icon">6,&nbsp;G<img src="../../logos/sharp.svg" alt="sharp" class="music-icon">6,&nbsp;A6,&nbsp;B6)</li>
             </ul>
         </li>
         <li>Guitar</li>


### PR DESCRIPTION
## Summary
- fix note octaves for the *Internal* instrumentation so the `6` is not superscript

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880011a2780832dafa368d440bd4ea8