### PR TITLE
Fix spacing for musical icons

### DIFF
--- a/style.css
+++ b/style.css
@@ -252,6 +252,7 @@ img {
     display: inline-block;
     /* Align musical accidentals with the surrounding text */
     vertical-align: -0.15em;
+    line-height: 0;
     /* Tighten spacing between accidentals and adjacent text */
     margin-left: -0.2em;
     margin-right: -0.2em;


### PR DESCRIPTION
## Summary
- prevent `.music-icon` items from affecting line height

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68800419df5c832dabc439c7a9f200a2