### PR TITLE
Add subtle animations for hero and lists

### DIFF
--- a/style.css
+++ b/style.css
@@ -193,7 +193,7 @@ header nav a {
     position: relative;
     color: #ffffff;
     opacity: 0.7;
-    transition: opacity 0.3s ease;
+    transition: opacity 0.3s ease, transform 0.3s ease;
 }
 header nav a::after {
     content: "";
@@ -212,6 +212,7 @@ header nav a::after {
 header nav a:hover,
 header nav a.active {
     opacity: 1;
+    transform: translateY(-2px);
 }
 
 header nav a:hover::after,
@@ -334,6 +335,11 @@ body.about .about-lines {
     margin-bottom: 1.5em;
     padding-left: 1em;
     border-left: 3px solid #555555;
+    transition: transform 0.3s ease, background-color 0.3s ease;
+}
+.works-list li:hover {
+    transform: translateX(5px);
+    background-color: rgba(255, 255, 255, 0.05);
 }
 .works-list li:last-child {
     margin-bottom: 0;
@@ -415,9 +421,14 @@ body.about .about-lines {
     margin-bottom: 1.5em;
     padding-left: 1em;
     border-left: 3px solid #555555;
+    transition: transform 0.3s ease, background-color 0.3s ease;
 }
 .events-list > li:last-child {
     margin-bottom: 0;
+}
+.events-list > li:hover {
+    transform: translateX(5px);
+    background-color: rgba(255, 255, 255, 0.05);
 }
 
 /* Nested list for program details within events */
@@ -507,6 +518,9 @@ body.about .about-lines {
 
 .hero h1 {
     font-size: 2em;
+    opacity: 0;
+    transform: translateY(20px);
+    animation: heroTitle 0.6s ease forwards;
 }
 
 .hero img {
@@ -516,6 +530,9 @@ body.about .about-lines {
     object-fit: cover;
     margin-top: 0;
     margin-bottom: 0;
+    opacity: 0;
+    transform: translateY(20px);
+    animation: heroImage 0.6s ease forwards;
 }
 
 
@@ -593,4 +610,12 @@ body.fade-out {
 @keyframes fadeOut {
     from { opacity: 1; }
     to { opacity: 0; }
+}
+
+@keyframes heroImage {
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes heroTitle {
+    to { opacity: 1; transform: translateY(0); }
 }


### PR DESCRIPTION
## Summary
- animate hero image and headings on load
- scale nav links on hover for a slight lift
- highlight works and events list items on hover

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68800227ab90832dbb2b2eaa52595595