### PR TITLE
Fix CSS spacing for music icons

### DIFF
--- a/style.css
+++ b/style.css
@@ -249,7 +249,7 @@ img {
 }
 .music-icon {
     width: 1em;
-    height: 1em;
+    height: 0.8em;
     display: inline-block;
     /* Align musical accidentals with the surrounding text */
     vertical-align: -0.15em;


### PR DESCRIPTION
## Summary
- refine `.music-icon` height to avoid expanding line spacing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688001f92c64832da7e51ea122aae4dc