### PR TITLE
Fix baseline alignment for musical icons

### DIFF
--- a/style.css
+++ b/style.css
@@ -252,7 +252,7 @@ img {
     height: 0.8em;
     display: inline-block;
     /* Align musical accidentals with the surrounding text */
-    vertical-align: -0.15em;
+    vertical-align: baseline;
     line-height: 0;
     /* Tighten spacing between accidentals and adjacent text */
     margin-left: -0.2em;


### PR DESCRIPTION
## Summary
- adjust `.music-icon` CSS to align with baseline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688007e8fe4c832daf1f2a62f67333a6