### PR TITLE
Keep hamburger icon lines when menu opens

### DIFF
--- a/style.css
+++ b/style.css
@@ -82,15 +82,15 @@ header .container {
 .menu-icon span:nth-child(2) { top: 8px; }
 .menu-icon span:nth-child(3) { top: 16px; }
 
-.menu-toggle:checked + .menu-icon span:nth-child(1) {
-    transform: translateY(8px) rotate(45deg);
-}
-.menu-toggle:checked + .menu-icon span:nth-child(2) {
-    opacity: 0;
-    transform: scaleX(0);
-}
+.menu-toggle:checked + .menu-icon span:nth-child(1),
+.menu-toggle:checked + .menu-icon span:nth-child(2),
 .menu-toggle:checked + .menu-icon span:nth-child(3) {
-    transform: translateY(-8px) rotate(-45deg);
+    transform: none;
+    opacity: 1;
+}
+
+.menu-toggle:checked + .menu-icon::before {
+    background-color: rgba(255, 255, 255, 0.12);
 }
 .logo {
     display: flex;


### PR DESCRIPTION
## Summary
- keep hamburger icon lines when menu is toggled
- show round background on toggle as well as hover

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68800e036968832db7cdd8887b0680b7