### PR TITLE
Fix menu backdrop size

### DIFF
--- a/style.css
+++ b/style.css
@@ -56,8 +56,8 @@ header .container {
     position: absolute;
     top: 50%;
     left: 50%;
-    width: 48px;
-    height: 48px;
+    width: 46px;
+    height: 46px;
     transform: translate(-50%, -50%);
     border-radius: 50%;
     background-color: transparent;


### PR DESCRIPTION
## Summary
- adjust the menu backdrop circle size

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68800eeeec28832d9d2d471fec09f6a8