### PR TITLE
Speed up mobile menu animation

### DIFF
--- a/style.css
+++ b/style.css
@@ -604,8 +604,8 @@ body.about .about-lines {
         opacity: 0;
         transform: translateY(-10px) scale(0.95);
         transform-origin: top right;
-        transition: max-height 0.3s ease, opacity 0.3s ease,
-                    transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+        transition: max-height 0.15s ease, opacity 0.15s ease,
+                    transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
     }
     .menu-toggle:checked + .menu-icon + nav {
         max-height: 350px;


### PR DESCRIPTION
## Summary
- shorten transition durations for mobile nav menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68801056a974832dac6b989ccf55bcbf