### PR TITLE
Add border to mobile nav menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -600,6 +600,7 @@ body.about .about-lines {
         overflow: hidden;
         gap: 0.25em;
         padding: 0.8em;
+        border: 1px solid #555555;
         max-height: 0;
         opacity: 0;
         transform: translateY(-10px) scale(0.95);


### PR DESCRIPTION
## Summary
- outline the mobile dropdown menu with a thin grey border

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688011c856d8832d86abe6836e8e2632