### PR TITLE
Fix mobile menu alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -590,13 +590,13 @@ body.about .about-lines {
     }
     nav {
         position: absolute;
-        top: 100%;
+        top: calc(100% - 1px);
         right: 2vw;
         background-color: #000000;
         flex-direction: column;
         align-items: flex-end;
         width: auto;
-        margin-top: 0.5em;
+        margin-top: 0;
         overflow: hidden;
         gap: 0.25em;
         padding: 0.8em;


### PR DESCRIPTION
## Summary
- make mobile dropdown menu appear directly above the header line

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688012d4278c832d99bb837f9966f6d3