### PR TITLE
Fix heading size and underline

### DIFF
--- a/style.css
+++ b/style.css
@@ -153,12 +153,12 @@ nav a {
 }
 h1 {
     font-weight: 300;
-    font-size: 2em;
+    font-size: 1.3em;
     margin: 1em 0 0.75em;
     text-transform: uppercase;
     letter-spacing: 0.15em;
-    border-bottom: none;
-    padding-bottom: 0;
+    border-bottom: 1px solid #555555;
+    padding-bottom: 0.5em;
 }
 h2 {
     font-weight: 300;


### PR DESCRIPTION
## Summary
- restore underline for section headings
- size section headings to match the tagline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882327fd65c832d95f5744e0d16590b