### PR TITLE
Fix spacing before past events header

### DIFF
--- a/style.css
+++ b/style.css
@@ -524,7 +524,7 @@ body.about .about-lines {
 .events-separator {
     border: 0;
     border-top: 1px solid #555555;
-    margin: 2em 0;
+    margin: 2em 0 1em;
 }
 .events-separator:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
## Summary
- reduce bottom margin on `.events-separator` so headings following it sit closer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882367145f0832db779675c99206399