### PR TITLE
Fix event section spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -524,7 +524,7 @@ body.about .about-lines {
 .events-separator {
     border: 0;
     border-top: 1px solid #555555;
-    margin: 2em 0 1em;
+    margin: 1em 0;
 }
 .events-separator:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
## Summary
- adjust spacing before the events separator to match works section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688238038048832d8e1b059389024cc1