### PR TITLE
Add link to Franck Bedrossian

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -32,7 +32,7 @@
             <h1>About</h1>
             <div class="about-text">
                 <p class="mid-margin"><a href="/">Leonardo Matteucci</a> is a composer exploring inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation.</p>
-                <p class="large-margin">He studied composition with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> in Turin (2019–2021) and <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> in Fermo (2021–2023), and is currently pursuing a Master’s degree under Franck Bedrossian at the <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
+                <p class="large-margin">He studied composition with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> in Turin (2019–2021) and <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> in Fermo (2021–2023), and is currently pursuing a Master’s degree under <a href="https://fr.wikipedia.org/wiki/Franck_Bedrossian" target="_blank">Franck Bedrossian</a> at the <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
             </div>
             <img src="../graphics/placeholder.svg" alt="Placeholder image" class="placeholder-image">
         </section>


### PR DESCRIPTION
## Summary
- link Franck Bedrossian text to Wikipedia page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68823a46c0b8832d9bdc525957583f76