### PR TITLE
Add meta descriptions to subpages

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Biography and artistic focus of composer Leonardo Matteucci, exploring corporeality and acoustic-electronic hybridisation.">
     <title>About - Leonardo Matteucci</title>
     <link rel="icon" href="../logos/lm-logo-favicon.svg" type="image/svg+xml">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">

--- a/events/index.html
+++ b/events/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Schedule of upcoming and past performances of Leonardo Matteucci's works with venues and performers.">
     <title>Events - Leonardo Matteucci</title>
     <link rel="icon" href="../logos/lm-logo-favicon.svg" type="image/svg+xml">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">

--- a/projects/index.html
+++ b/projects/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Overview of Leonardo Matteucci's collaborative projects, including the Reach.Touch. series.">
     <title>Projects - Leonardo Matteucci</title>
     <link rel="icon" href="../logos/lm-logo-favicon.svg" type="image/svg+xml">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">

--- a/works/index.html
+++ b/works/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Catalogue of compositions by Leonardo Matteucci with instrumentation and year of creation.">
     <title>Works - Leonardo Matteucci</title>
     <link rel="icon" href="../logos/lm-logo-favicon.svg" type="image/svg+xml">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- add succinct meta description tags for the About, Projects, Events and Works pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826b68bc98832db3e23284cec9e1e4