### PR TITLE
Adjust mobile header sizing and center tagline

### DIFF
--- a/style.css
+++ b/style.css
@@ -139,6 +139,9 @@ main {
     color: #ffffff;
     font-style: normal;
     font-weight: 300;
+    text-align: center;
+    max-width: 100%;
+    white-space: normal;
 }
 .tagline:hover {
     text-decoration: none;
@@ -697,17 +700,17 @@ body.fade-out {
 
 @media (max-width: 600px) {
     :root {
-        --header-height: 96px;
+        --header-height: 90px;
     }
     header .container {
-        padding: 0.75em 2vw;
+        padding: 0.6em 2vw;
     }
     .tagline {
-        font-size: 1.1em;
+        font-size: 1em;
     }
     header nav a {
-        font-size: 0.85em;
-        padding: 0.25em 0;
+        font-size: 0.8em;
+        padding: 0.2em 0;
     }
     main {
         margin-top: var(--header-height);


### PR DESCRIPTION
## Summary
- tweak mobile header sizing for small screens
- ensure the tagline wraps and stays centered on narrow widths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68826d977604832d8671fdde3461c2c5