### PR TITLE
Fix mobile nav item font size

### DIFF
--- a/style.css
+++ b/style.css
@@ -709,7 +709,7 @@ body.fade-out {
         font-size: 1em;
     }
     header nav a {
-        font-size: 0.8em;
+        font-size: 0.95em;
         padding: 0.2em 0;
     }
     main {


### PR DESCRIPTION
## Summary
- keep menu items legible on small screens by increasing the font size in the mobile media query

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68826efb44f4832da4ca5f04e6bbecdf