### PR TITLE
Set underline color on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -718,6 +718,7 @@ body.fade-out {
     a,
     .link {
         text-decoration: underline;
+        text-decoration-color: #555555;
     }
     header nav a::after {
         display: none;


### PR DESCRIPTION
## Summary
- style tweak: match mobile link underline color to separator gray

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826f7bed5c832daa0261a64a2b01d5