### PR TITLE
Fix mobile underline for hero and menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -719,6 +719,10 @@ body.fade-out {
     .link {
         text-decoration: underline;
     }
+    .tagline,
+    header nav a {
+        text-decoration: none;
+    }
     header nav a::after {
         display: none;
     }


### PR DESCRIPTION
## Summary
- avoid underlining hero tagline and menu items on small screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68826fa85fe0832d94c479340ee9a7e0