### PR TITLE
Fix paragraph spacing on about page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -32,7 +32,7 @@
         <section class="about-lines">
             <h1>About</h1>
             <div class="about-text">
-                <p class="mid-margin"><a href="/">Leonardo Matteucci</a> is a composer exploring inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation.</p>
+                <p><a href="/">Leonardo Matteucci</a> is a composer exploring inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation.</p>
                 <p>He studied composition with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> in Turin (2019–2021) and <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> in Fermo (2021–2023), and is currently pursuing a Master’s degree under <a href="https://fr.wikipedia.org/wiki/Franck_Bedrossian" target="_blank">Franck Bedrossian</a> at the <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
             </div>
             <img src="../graphics/placeholder.svg" alt="Placeholder image" class="placeholder-image">


### PR DESCRIPTION
## Summary
- remove extra margin class from first paragraph in the about section

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688283c31d20832dace828b2e43b302d