### PR TITLE
Adjust mobile link underline appearance

### DIFF
--- a/style.css
+++ b/style.css
@@ -719,6 +719,8 @@ body.fade-out {
     .link {
         text-decoration: underline;
         text-decoration-color: #555555;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 0.2em;
     }
     .tagline,
     header nav a {


### PR DESCRIPTION
## Summary
- make mobile link underlines slightly thicker and offset from the text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68828732b4e0832d8cd53785c7430792