### PR TITLE
Adjust mobile link underline thickness

### DIFF
--- a/style.css
+++ b/style.css
@@ -719,7 +719,7 @@ body.fade-out {
     .link {
         text-decoration: underline;
         text-decoration-color: #555555;
-        text-decoration-thickness: 2px;
+        text-decoration-thickness: 1px;
         text-underline-offset: 0.2em;
     }
     .tagline,


### PR DESCRIPTION
## Summary
- ensure link underlines on small screens match separator line style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68828865dd14832dafe69c231db9defd