### PR TITLE
Refine index titles

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -33,7 +33,7 @@
             <h1>Projects</h1>
             <ul class="works-list">
                 <li>
-                    <span class="works-title"><a href="/projects/reach-touch/" class="link">Reach.Touch.</a> (2025)</span>
+                    <span class="list-title"><a href="/projects/reach-touch/" class="link">Reach.Touch.</a> (2025)</span>
                     <span class="works-details italic">works by Matteucci, Sarmiento, and Savagnone</span>
                 </li>
             </ul>

--- a/style.css
+++ b/style.css
@@ -409,6 +409,19 @@ body.about .about-lines {
 .works-list li:last-child {
     margin-bottom: 0;
 }
+
+/* Titles for entries in the Works and Projects index pages */
+.list-title {
+    display: block;
+    font-weight: 300;
+    font-size: 1.1em;
+    margin: 0.5em 0 0.3em;
+    text-transform: none;
+    letter-spacing: normal;
+    text-align: left;
+}
+
+/* Hero‑style title used on individual work and project pages */
 .works-title {
     display: block;
     font-weight: 300;

--- a/works/index.html
+++ b/works/index.html
@@ -33,30 +33,30 @@
             <h1>Works</h1>
             <ul class="works-list">
                 <li>
-                    <span class="works-title">Dehiscence (2026)</span>
+                    <span class="list-title">Dehiscence (2026)</span>
                     <span class="works-details italic">for ensemble and electronics <span class="separator">&bull;</span> <span class="no-italic">Upcoming</span></span>
                 </li>
             </ul>
             <hr class="works-separator">
             <ul class="works-list">
                 <li>
-                    <span class="works-title"><a href="/works/occlusion/" class="link">Occlusion</a> (2025)</span>
+                    <span class="list-title"><a href="/works/occlusion/" class="link">Occlusion</a> (2025)</span>
                     <span class="works-details italic">for violin and electronics</span>
                 </li>
                 <li>
-                    <span class="works-title"><a href="/works/assume/" class="link">Assume</a> (2025)</span>
+                    <span class="list-title"><a href="/works/assume/" class="link">Assume</a> (2025)</span>
                     <span class="works-details italic">for piano, flute, cello and electronics</span>
                 </li>
                 <li>
-                    <span class="works-title"><a href="/works/bodylines/" class="link">Bodylines</a> (2023)</span>
+                    <span class="list-title"><a href="/works/bodylines/" class="link">Bodylines</a> (2023)</span>
                     <span class="works-details italic">for violin, piccolo and electronics</span>
                 </li>
                 <li>
-                    <span class="works-title"><a href="/works/internal/" class="link">Internal</a> (2023)</span>
+                    <span class="list-title"><a href="/works/internal/" class="link">Internal</a> (2023)</span>
                     <span class="works-details italic">for ensemble</span>
                 </li>
                 <li>
-                    <span class="works-title"><a href="/works/a-uno-spirituale-in-firenze/" class="link">A uno spirituale in Firenze</a> (2021)</span>
+                    <span class="list-title"><a href="/works/a-uno-spirituale-in-firenze/" class="link">A uno spirituale in Firenze</a> (2021)</span>
                     <span class="works-details italic">for string quartet and electronics</span>
                 </li>
             </ul>


### PR DESCRIPTION
## Summary
- add `list-title` CSS for index listing pages
- keep `works-title` hero style for individual pages
- update Works and Projects index pages to use `list-title`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68828ac20e24832d8ff73c9a1db42e08