### PR TITLE
Align works index titles with events style

### DIFF
--- a/style.css
+++ b/style.css
@@ -414,11 +414,7 @@ body.about .about-lines {
 .list-title {
     display: block;
     font-weight: 300;
-    font-size: 1.1em;
-    margin: 0.5em 0 0.3em;
-    text-transform: none;
-    letter-spacing: normal;
-    text-align: left;
+    margin-top: 0;
 }
 
 /* Hero‑style title used on individual work and project pages */


### PR DESCRIPTION
## Summary
- unify the `.list-title` style used in Works and Projects index pages with the
  same styling as event titles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68828cc8c10c832da4f65a1e045eef82