### PR TITLE
Improve back arrow layout

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -28,7 +28,7 @@
         </div>
     </header>
     <main>
-    <a href="/projects/" class="back-link">&larr; Go back</a>
+    <a href="/projects/" class="back-link" aria-label="Go back">&larr;</a>
 
 <section class="reach-touch">
     <p class="works-title">Reach.Touch. (2025)</p>

--- a/style.css
+++ b/style.css
@@ -116,6 +116,7 @@ main {
     margin-left: auto;
     margin-right: auto;
     padding: 0 2vw calc(var(--footer-height) + 1em);
+    position: relative;
 }
 .logo img {
     width: 60px;
@@ -352,8 +353,14 @@ img {
 
 /* Generic back button for detail pages */
 .back-link {
-    display: inline-block;
-    margin: 1em 0;
+    position: absolute;
+    top: 0;
+    left: 0;
+    margin: 0;
+    padding: 0.5em;
+    font-size: 1.5em;
+    line-height: 1;
+    text-decoration: none;
 }
 section {
     margin-bottom: 3em;

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -28,7 +28,7 @@
         </div>
     </header>
     <main>
-    <a href="/works/" class="back-link">&larr; Go back</a>
+    <a href="/works/" class="back-link" aria-label="Go back">&larr;</a>
     <section>
     <p class="works-title">A uno spirituale in Firenze (2021)</p>
     <p class="works-details italic align-center">in memoria di Carla Massini</p>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -28,7 +28,7 @@
         </div>
     </header>
     <main>
-    <a href="/works/" class="back-link">&larr; Go back</a>
+    <a href="/works/" class="back-link" aria-label="Go back">&larr;</a>
     <section>
     <p class="works-title">Assume (2025)</p>
     <p class="works-details italic align-center"></p>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -28,7 +28,7 @@
         </div>
     </header>
     <main>
-    <a href="/works/" class="back-link">&larr; Go back</a>
+    <a href="/works/" class="back-link" aria-label="Go back">&larr;</a>
     <section>
     <p class="works-title">Bodylines (2023)</p>
     <p class="works-details italic align-center"></p>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -28,7 +28,7 @@
         </div>
     </header>
     <main>
-    <a href="/works/" class="back-link">&larr; Go back</a>
+    <a href="/works/" class="back-link" aria-label="Go back">&larr;</a>
     <section>
     <p class="works-title">Internal (2023)</p>
     <p class="works-details align-center" style="color: #ffffff;">10′</p>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -28,7 +28,7 @@
         </div>
     </header>
     <main>
-    <a href="/works/" class="back-link">&larr; Go back</a>
+    <a href="/works/" class="back-link" aria-label="Go back">&larr;</a>
     <section>
     <p class="works-title">Occlusion (2025)</p>
     <p class="works-details italic align-center"></p>


### PR DESCRIPTION
## Summary
- overlay the back arrow so it doesn't shift content
- keep only the symbol in detail pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68837f1b152c832d83415595a2a0397c