### PR TITLE
Fix back button alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -355,7 +355,7 @@ img {
 .back-link {
     position: absolute;
     top: 0.9em;
-    left: 0;
+    left: 2vw;
     margin: 0;
     padding: 0.5em;
     line-height: 0;
@@ -790,5 +790,8 @@ body.fade-out {
     }
     header nav a::after {
         display: none;
+    }
+    .back-link {
+        left: 4vw;
     }
 }


### PR DESCRIPTION
## Summary
- align `.back-link` with hero logo by offsetting it from the page edge
- keep alignment on small screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688382426bf4832dbf7077c524e9288b