### PR TITLE
Fix detail page back button placement

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -11,7 +11,6 @@
 <body>
     <header>
         <div class="container">
-        <a href="/projects/" class="back-link" aria-label="Go back"><img src="../../logos/back-arrow_white.svg" alt="Go back"></a>
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../../logos/lm-logo-favicon.svg" alt="logo">
@@ -28,7 +27,8 @@
         </nav>
         </div>
     </header>
-    <main>
+<main>
+    <a href="/projects/" class="back-link" aria-label="Go back"><img src="../../logos/back-arrow_white.svg" alt="Go back"></a>
 <section class="reach-touch">
     <p class="works-title">Reach.Touch. (2025)</p>
     <p class="works-details align-center duration" style="margin-bottom: 0;">1h10′</p>

--- a/style.css
+++ b/style.css
@@ -353,17 +353,18 @@ img {
 
 /* Generic back button for detail pages */
 .back-link {
-    display: flex;
-    align-items: center;
-    margin-right: 1em;
+    position: absolute;
+    top: 0.9em;
+    left: 2vw;
+    margin: 0;
     padding: 0.5em;
     line-height: 0;
     text-decoration: none;
 }
 
 .back-link img {
-    width: 60px;
-    height: 60px;
+    width: 24px;
+    height: 24px;
 }
 section {
     margin-bottom: 3em;
@@ -790,8 +791,7 @@ body.fade-out {
     header nav a::after {
         display: none;
     }
-    .back-link img {
-        width: 50px;
-        height: 50px;
+    .back-link {
+        left: 4vw;
     }
 }

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -11,7 +11,6 @@
 <body>
     <header>
         <div class="container">
-        <a href="/works/" class="back-link" aria-label="Go back"><img src="../../logos/back-arrow_white.svg" alt="Go back"></a>
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../../logos/lm-logo-favicon.svg" alt="logo">
@@ -28,7 +27,8 @@
         </nav>
         </div>
     </header>
-    <main>
+<main>
+    <a href="/works/" class="back-link" aria-label="Go back"><img src="../../logos/back-arrow_white.svg" alt="Go back"></a>
     <section>
     <p class="works-title">A uno spirituale in Firenze (2021)</p>
     <p class="works-details align-center duration">5′</p>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -11,7 +11,6 @@
 <body>
     <header>
         <div class="container">
-        <a href="/works/" class="back-link" aria-label="Go back"><img src="../../logos/back-arrow_white.svg" alt="Go back"></a>
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../../logos/lm-logo-favicon.svg" alt="logo">
@@ -28,7 +27,8 @@
         </nav>
         </div>
     </header>
-    <main>
+<main>
+    <a href="/works/" class="back-link" aria-label="Go back"><img src="../../logos/back-arrow_white.svg" alt="Go back"></a>
     <section>
     <p class="works-title">Assume (2025)</p>
     <p class="works-details align-center duration">15′</p>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -11,7 +11,6 @@
 <body>
     <header>
         <div class="container">
-        <a href="/works/" class="back-link" aria-label="Go back"><img src="../../logos/back-arrow_white.svg" alt="Go back"></a>
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../../logos/lm-logo-favicon.svg" alt="logo">
@@ -28,7 +27,8 @@
         </nav>
         </div>
     </header>
-    <main>
+<main>
+    <a href="/works/" class="back-link" aria-label="Go back"><img src="../../logos/back-arrow_white.svg" alt="Go back"></a>
     <section>
     <p class="works-title">Bodylines (2023)</p>
     <p class="works-details align-center duration">7′30″</p>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -11,7 +11,6 @@
 <body>
     <header>
         <div class="container">
-        <a href="/works/" class="back-link" aria-label="Go back"><img src="../../logos/back-arrow_white.svg" alt="Go back"></a>
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../../logos/lm-logo-favicon.svg" alt="logo">
@@ -28,7 +27,8 @@
         </nav>
         </div>
     </header>
-    <main>
+<main>
+    <a href="/works/" class="back-link" aria-label="Go back"><img src="../../logos/back-arrow_white.svg" alt="Go back"></a>
     <section>
     <p class="works-title">Internal (2023)</p>
     <p class="works-details align-center duration">10′</p>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -11,7 +11,6 @@
 <body>
     <header>
         <div class="container">
-        <a href="/works/" class="back-link" aria-label="Go back"><img src="../../logos/back-arrow_white.svg" alt="Go back"></a>
         <div class="logo">
             <a href="/" title="Home">
                 <img src="../../logos/lm-logo-favicon.svg" alt="logo">
@@ -28,7 +27,8 @@
         </nav>
         </div>
     </header>
-    <main>
+<main>
+    <a href="/works/" class="back-link" aria-label="Go back"><img src="../../logos/back-arrow_white.svg" alt="Go back"></a>
     <section>
     <p class="works-title">Occlusion (2025)</p>
     <p class="works-details align-center duration">9′30″</p>


### PR DESCRIPTION
## Summary
- restore 24px back button sizing and absolute positioning
- move back button back below `<header>` on detail pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688386f44ea0832db4376011df88452e