### PR TITLE
Fix desktop menu layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -44,7 +44,7 @@ header .container {
     display: none;
 }
 .menu-icon {
-    display: block;
+    display: none;
     width: 24px;
     height: 18px;
     position: relative;
@@ -91,9 +91,6 @@ header .container {
 
 .menu-toggle:checked + .menu-icon::before {
     background-color: rgba(255, 255, 255, 0.12);
-}
-#menu-toggle:checked + .menu-icon + nav {
-    display: flex;
 }
 .logo {
     display: flex;
@@ -233,17 +230,11 @@ header nav a:hover {
     text-decoration: none;
 }
 header nav {
-    display: none;
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    margin-left: 0;
-    flex-direction: column;
-    gap: 0.5em;
-    background-color: #000000;
-    border-bottom: 1px solid #555555;
-    padding: 1em 4vw;
+    margin-left: auto;
+    display: flex;
+    gap: 1em;
+    align-items: center;
+    flex-direction: row;
 }
 header nav a {
     position: relative;
@@ -736,6 +727,25 @@ body.fade-out {
     }
     .tagline {
         font-size: 1em;
+    }
+    .menu-icon {
+        display: block;
+    }
+    header nav {
+        display: none;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        margin-left: 0;
+        flex-direction: column;
+        gap: 0.5em;
+        background-color: #000000;
+        border-bottom: 1px solid #555555;
+        padding: 1em 4vw;
+    }
+    #menu-toggle:checked + .menu-icon + nav {
+        display: flex;
     }
     header nav a {
         font-size: 1.2em;


### PR DESCRIPTION
## Summary
- keep hamburger icon hidden on desktops
- restore horizontal desktop navigation
- re-add mobile dropdown styling with thin gray border

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68838b8e444c832db4cb064e32bad3ac