### PR TITLE
Reduce title spacing below header

### DIFF
--- a/style.css
+++ b/style.css
@@ -161,7 +161,7 @@ nav a {
 h1 {
     font-weight: 300;
     font-size: 1.3em;
-    margin: 1em 0 0.75em;
+    margin: 0.5em 0 0.75em;
     text-transform: uppercase;
     letter-spacing: 0.15em;
     padding-bottom: 0.5em;
@@ -450,7 +450,7 @@ body.about .about-lines {
     display: block;
     font-weight: 300;
     font-size: 1.3em;
-    margin: 1em 0 0.5em;
+    margin: 0.5em 0 0.5em;
     text-transform: uppercase;
     letter-spacing: 0.15em;
     padding-bottom: 0.5em;


### PR DESCRIPTION
## Summary
- adjust `h1` margin-top so titles sit closer to the header
- match `.works-title` spacing for consistency

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e310b1c0832d8ab7af3bef34a089