### PR TITLE
Fix menu underline alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -35,6 +35,10 @@ header {
 }
 
 header::after {
+    display: none;
+}
+
+header .container::after {
     content: "";
     position: absolute;
     bottom: 0;


### PR DESCRIPTION
## Summary
- center the header's underline relative to the content container

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883e5dd17d4832dba120151d8855944