### PR TITLE
Revert header underline changes

### DIFF
--- a/style.css
+++ b/style.css
@@ -35,10 +35,6 @@ header {
 }
 
 header::after {
-    display: none;
-}
-
-header .container::after {
     content: "";
     position: absolute;
     bottom: 0;


### PR DESCRIPTION
## Summary
- revert the recent header underline change that hid `header::after` and moved the underline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883e718c45c832d99f119fb94b298f3