### PR TITLE
Ensure project titles grey

### DIFF
--- a/style.css
+++ b/style.css
@@ -513,6 +513,12 @@ body.about .about-lines {
 .works-details a:hover {
     color: #bbbbbb;
 }
+.works-details .link {
+    color: #bbbbbb;
+}
+.works-details .link:hover {
+    color: #bbbbbb;
+}
 
 /* Separator inside works details should match the surrounding text color */
 .works-details .separator {


### PR DESCRIPTION
## Summary
- keep text for project titles in commission/supporter/dedication lines grey by overriding `.link` color in `.works-details`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883e884f74c832d8c4e589687cc1906