### PR TITLE
Fix spacing on Reach.Touch program list

### DIFF
--- a/style.css
+++ b/style.css
@@ -504,6 +504,9 @@ body.about .about-lines {
     color: #bbbbbb;
     margin-top: 0;
 }
+.reach-touch .about-text .works-details {
+    margin-top: 0.5em;
+}
 .works-details.italic {
     font-style: italic;
 }


### PR DESCRIPTION
## Summary
- tweak spacing for program items on Reach.Touch page so composer, title and instrumentation have equal separation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883eaffbaec832dbc01edbd6f01eac7