### PR TITLE
Ensure consistent spacing after separators

### DIFF
--- a/style.css
+++ b/style.css
@@ -682,7 +682,7 @@ body.about .about-lines {
 hr[class*="separator"] + h1,
 hr[class*="separator"] + h2,
 hr[class*="separator"] + h3 {
-    margin-top: 0;
+    margin-top: 0.75em;
 }
 
 .intermission-text {


### PR DESCRIPTION
## Summary
- fix the margin above section headings that follow a separator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883ebc10a2c832db9fb47499c26f734