### PR TITLE
Revert spacing change for section headings

### DIFF
--- a/style.css
+++ b/style.css
@@ -682,7 +682,7 @@ body.about .about-lines {
 hr[class*="separator"] + h1,
 hr[class*="separator"] + h2,
 hr[class*="separator"] + h3 {
-    margin-top: 0.75em;
+    margin-top: 0;
 }
 
 .intermission-text {


### PR DESCRIPTION
## Summary
- revert PR #351 that set margin-top on headings after separators

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883ed11f8ec832d91543488f2580cba