### PR TITLE
Adjust events separator spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -637,7 +637,7 @@ body.about .about-lines {
 .events-separator {
     border: 0;
     border-top: 1px solid #555555;
-    margin: 1em 0;
+    margin: 1em 0 0;
 }
 .events-separator:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
## Summary
- tweak `.events-separator` bottom margin so the gap above **Past Events** header is 0.75em

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883ed4bc988832da336b85d87d31d09