### PR TITLE
Fix spacing for work and project titles

### DIFF
--- a/style.css
+++ b/style.css
@@ -500,12 +500,16 @@ body.about .about-lines {
     display: block;
     font-weight: 300;
     font-size: 1.3em;
-    margin: 1em 0 0.5em;
+    margin: var(--spacing-large) 0 var(--spacing-small);
     text-transform: uppercase;
     letter-spacing: 0.15em;
     padding-bottom: 0.5em;
     text-align: center;
     position: relative;
+}
+
+main > section:first-of-type > .works-title:first-child {
+    margin-top: 0;
 }
 
 .works-title::after {
@@ -514,7 +518,7 @@ body.about .about-lines {
     bottom: 0;
     left: 50%;
     transform: translateX(-50%);
-    width: 50%;
+    width: var(--separator-width);
     border-bottom: 1px solid #555555;
 }
 .works-details {


### PR DESCRIPTION
## Summary
- unify `.works-title` margins with `<h1>` section headings
- remove extra top margin on first sections
- use variable for underline width

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f974eed0832db48cbfa389244848