### PR TITLE
Align menu with section titles

### DIFF
--- a/style.css
+++ b/style.css
@@ -107,6 +107,34 @@ header .container {
 }
 #menu-toggle:checked + .menu-icon + nav {
     display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+#menu-toggle:checked + .menu-icon + nav a {
+    margin: var(--spacing-large) 0 var(--spacing-small);
+    padding-bottom: 0.5em;
+    font-size: 1.3em;
+    font-weight: 300;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    text-align: center;
+    position: relative;
+    opacity: 1;
+    transform: none;
+}
+
+#menu-toggle:checked + .menu-icon + nav a::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: var(--separator-width);
+    height: 0;
+    border-bottom: 1px solid #555555;
+    background: none;
+    opacity: 1;
 }
 .logo {
     display: flex;


### PR DESCRIPTION
## Summary
- style menu items like section titles when the menu is open
- stack menu items vertically and center them
- match separator position with section titles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883fc043738832d9ffeeab9646ccb84