### PR TITLE
Fix Reach.Touch program spacing

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -31,8 +31,7 @@
     <a href="/projects/" class="back-link" aria-label="Go back"><img src="../../logos/back-arrow_white.svg" alt="Go back"></a>
 <section class="reach-touch">
     <p class="works-title">Reach.Touch. (2025)</p>
-    <p class="works-details align-center duration" style="margin-bottom: 0;">1h10′</p>
-    <hr class="works-separator">
+    <p class="works-details align-center duration">1h10′</p>
     <div class="about-text">
         <p class="regular">Juan Sarmiento (*2002)</p>
         <p class="regular">Decir adiós (from <span class="italic">Widmung</span>)</p>


### PR DESCRIPTION
## Summary
- removed the separator below the duration line in Reach.Touch
- reverted the duration element to default bottom margin so program text aligns with other works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688404542d6c832d920f156d6425cce0