### PR TITLE
Fix premiere link color

### DIFF
--- a/style.css
+++ b/style.css
@@ -650,6 +650,15 @@ main > section:first-of-type > .works-title:first-child {
 .premiere {
     color: #bbbbbb;
 }
+/* Ensure premiere links match the surrounding gray */
+.premiere a,
+.premiere .link {
+    color: #bbbbbb;
+}
+.premiere a:hover,
+.premiere .link:hover {
+    color: #bbbbbb;
+}
 
 .separator {
     color: #ffffff;


### PR DESCRIPTION
## Summary
- match premiere link color with the same gray used for works details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884060c9884832dbb7a60e6e2b16181