### PR TITLE
Fix menu baseline alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -302,6 +302,8 @@ header nav a {
     color: #ffffff;
     opacity: 0.7;
     transition: opacity 0.3s ease, transform 0.3s ease;
+    display: inline-block;
+    line-height: 1.6; /* Align with heading baseline */
 }
 header nav a.link {
     font-weight: 300;
@@ -310,6 +312,7 @@ header nav a::after {
     content: "";
     position: absolute;
     left: 0;
+    right: 0;
     bottom: -0.25px;
     width: 100%;
     height: 2px;


### PR DESCRIPTION
## Summary
- align menu item baseline with section titles
- extend underline across the full menu item

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688406b32274832d921f6b195749a43a