### PR TITLE
Adjust menu spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -277,7 +277,11 @@ header nav {
     justify-content: space-evenly;
     align-items: center;
     background-color: #000000;
-    padding: 1em 4vw 0.5em;
+    /*
+     * Align the menu directly beneath the header's bottom line with
+     * precisely spaced padding above and below the menu items.
+     */
+    padding: 0.75em 4vw 0.5em;
 }
 
 header nav::before,
@@ -296,6 +300,8 @@ header nav::before {
 
 header nav::after {
     bottom: 0;
+    /* Use full width for the menu's bottom separator */
+    width: 100%;
 }
 header nav a {
     position: relative;


### PR DESCRIPTION
## Summary
- adjust header menu padding so items start 0.75em below the header line
- make menu's bottom separator full width

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884bb76bd10832d81f7824345e57d85