### PR TITLE
Fix Reach.Touch program layout

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -32,41 +32,49 @@
 <section class="reach-touch">
     <p class="works-title">Reach.Touch. (2025)</p>
     <p class="works-details align-center duration">1h10′</p>
+    <p class="regular">Juan Sarmiento (*2002)</p>
     <div class="about-text">
-        <p class="regular">Juan Sarmiento (*2002)</p>
         <p class="regular">Decir adiós (from <span class="italic">Widmung</span>)</p>
         <p class="works-details italic mid-margin">for piano and electronics</p>
+    </div>
+    <div class="about-text">
         <p class="regular">Black bells (from <span class="italic">Widmung</span>)</p>
         <p class="works-details italic mid-margin">for piano</p>
+    </div>
+    <div class="about-text">
         <p class="regular"><span class="italic">[New work]</span> (from <span class="italic">Widmung</span>)</p>
         <p class="works-details italic mid-margin">for piano and electronics</p>
+    </div>
+    <div class="about-text">
         <p class="regular">Lindar algo con otro</p>
         <p class="works-details italic">for piano</p>
     </div>
     <hr class="works-separator-half">
+    <p class="regular">Emanuele Savagnone (*1997)</p>
     <div class="about-text">
-        <p class="regular">Emanuele Savagnone (*1997)</p>
         <p class="regular">stars on black canvas</p>
         <p class="works-details italic">for piano</p>
     </div>
     <p class="regular align-right gray intermission-text"><span class="italic">INTERMISSION</span></p>
     <hr class="works-separator-small">
+    <p class="regular">Leonardo Matteucci (*2000)</p>
     <div class="about-text">
-        <p class="regular">Leonardo Matteucci (*2000)</p>
         <p class="regular"><a href="/works/assume/" class="link">Assume</a></p>
         <p class="works-details italic">for piano, flute, cello and electronics</p>
     </div>
     <hr class="works-separator-half">
+    <p class="regular">Juan Sarmiento (*2002)</p>
     <div class="about-text">
-        <p class="regular">Juan Sarmiento (*2002)</p>
         <p class="regular">Caminos (from <span class="italic">Widmung</span>)</p>
         <p class="works-details italic mid-margin">for electronics</p>
+    </div>
+    <div class="about-text">
         <p class="regular">Choral (from <span class="italic">Widmung</span>)</p>
         <p class="works-details italic">for piano and electronics</p>
     </div>
     <hr class="works-separator-half">
+    <p class="regular">Leonardo Matteucci (*2000)</p>
     <div class="about-text">
-        <p class="regular">Leonardo Matteucci (*2000)</p>
         <p class="regular"><a href="/works/occlusion/" class="link">Occlusion</a></p>
         <p class="works-details italic">for violin and electronics</p>
     </div>

--- a/style.css
+++ b/style.css
@@ -701,7 +701,7 @@ main > section:first-of-type > .works-title:first-child {
 .works-separator-half {
     border: 0;
     border-top: 1px solid #555555;
-    margin: var(--spacing-small) auto;
+    margin: var(--spacing-small) 0;
     width: 50%;
 }
 .works-separator-half:last-child {


### PR DESCRIPTION
## Summary
- adjust `Reach.Touch.` program separators to align left
- show each piece with its own left border just like works listings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884bca20f78832d8c31ac1ac442fa16