### PR TITLE
Adjust menu padding to match headings

### DIFF
--- a/style.css
+++ b/style.css
@@ -281,7 +281,7 @@ header nav {
      * Align the menu directly beneath the header's bottom line with
      * precisely spaced padding above and below the menu items.
      */
-    padding: 0.75em 4vw 0.5em;
+    padding: 1em 4vw 0.5em;
 }
 
 header nav::before,


### PR DESCRIPTION
## Summary
- adjust menu padding to use `1em` top padding to match `h1` spacing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884bd1779c8832d9c05ef50f205a4b7