### PR TITLE
Update separators on Reach.Touch page

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -71,7 +71,7 @@
         <p class="works-details italic">for violin and electronics</p>
     </div>
 
-    <hr class="works-separator-small">
+    <hr class="works-separator">
     <p class="italic"><span style="font-style: normal;">Reach.Touch.</span> is a concert project whose themes focus on hidden bodily mechanics: movements that bend, compress, and collapse.</p>
     <p class="italic">There are moments when the internal tensions of our bodies escape, manifesting directly through sound—raw emissions tracing the most direct path from interior to exterior, emerging precisely where musical articulation first takes shape. Here, sound reveals a humanity stripped of rhetoric, a bare caress of the body's inner movements.</p>
     <p class="italic">This visceral intimacy—where touching implies reaching outward—has always represented, to me, an attempt at contact, at correspondence, or at least an affection driven by an urgent need to reach, a commitment to both the musicians' physical gestures and the internal bodily responses of the audience.</p>
@@ -79,6 +79,7 @@
     <p class="italic">Dynamics, therefore, become less about physical intensity and more about unveiling the potency of gesture at its fullest—amplified to clarity without distortion or strain.</p>
     <p class="italic">Intimacy demands proximity: listeners must lean in to discern between what is here and what is almost here, between what is touching and what is only attempting to reach. In this delicate space, what is fully present gradually meets what merely shimmers at the edge of perception—where neighboring domains touch without merging.</p>
     <p class="align-right" style="font-style: normal;">Leonardo Matteucci</p>
+    <hr class="works-separator-small">
     <p class="works-details italic align-right"><span class="regular link" style="font-style: normal;">Reach.Touch.</span> is a concert project supported by
         <a href="https://www.land.steiermark.at/" target="_blank">Land Steiermark</a>,
         the <a href="https://www.oehkug.at/" target="_blank">ÖH-KUG</a>, and


### PR DESCRIPTION
## Summary
- fix the separator between concert program and notes on the Reach.Touch. project page
- add a separator before the supporter line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884bd7cc234832d9ed5a0e2e79b893d