### PR TITLE
Add hover animation for Reach.Touch links

### DIFF
--- a/style.css
+++ b/style.css
@@ -477,6 +477,14 @@ body.about .about-lines {
 .about-text p.mid-margin {
     margin-bottom: 1.5em;
 }
+.reach-touch .about-text {
+    transition: transform 0.3s ease, background-color 0.3s ease;
+}
+.reach-touch .about-text:hover:has(a) {
+    transform: translateX(5px);
+    /* Slightly brighter hover background */
+    background-color: rgba(255, 255, 255, 0.12);
+}
 .works-list {
     list-style-type: none;
     padding: 0;


### PR DESCRIPTION
## Summary
- animate about-text entries in Reach.Touch when they contain a link

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884bef92138832dbc3cb67e2cf9b963