### PR TITLE
Fix navigation alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -269,7 +269,11 @@ header nav a:hover {
 header nav {
     display: none;
     position: absolute;
-    top: 100%;
+    /*
+     * Offset the menu by the 1px border drawn via `header::after` so the
+     * bottom separator aligns perfectly with section headings.
+     */
+    top: calc(100% + 1px);
     left: 0;
     right: 0;
     margin-left: 0;


### PR DESCRIPTION
## Summary
- offset `header nav` by 1px to align its bottom border with section titles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884c0d37f1c832dae672f25edb1c3a5