### PR TITLE
Align back button with hero

### DIFF
--- a/style.css
+++ b/style.css
@@ -416,7 +416,8 @@ img {
 .back-link {
     position: absolute;
     top: 0.9em;
-    left: 2vw;
+    left: 50%;
+    transform: translateX(-50%);
     margin: 0;
     padding: 0.5em;
     line-height: 0;
@@ -424,8 +425,8 @@ img {
 }
 
 .back-link img {
-    width: 24px;
-    height: 24px;
+    width: 48px;
+    height: 48px;
 }
 section {
     margin-bottom: 3em;
@@ -855,6 +856,7 @@ body.fade-out {
         display: none;
     }
     .back-link {
-        left: 4vw;
+        left: 50%;
+        transform: translateX(-50%);
     }
 }


### PR DESCRIPTION
## Summary
- center the back link relative to the page
- enlarge back arrow slightly so it's smaller than the logo but more prominent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884c39e9464832d8ca611499951d7f5