### PR TITLE
Add piece spacing on Reach.Touch

### DIFF
--- a/style.css
+++ b/style.css
@@ -474,7 +474,11 @@ body.about .about-lines {
     margin-bottom: 0.5em;
 }
 .reach-touch .about-text {
+    margin-bottom: var(--spacing-large);
     transition: transform 0.3s ease, background-color 0.3s ease;
+}
+.reach-touch .about-text:last-child {
+    margin-bottom: 0;
 }
 .reach-touch .about-text:hover:has(a) {
     transform: translateX(5px);


### PR DESCRIPTION
## Summary
- add 1em bottom margin for `.reach-touch .about-text`
- avoid extra spacing on the final piece entry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884cd6f1914832db8d5eb45ddf48c8b