### PR TITLE
Fix heading padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -190,7 +190,7 @@ h1 {
     margin: 0 0 var(--spacing-small);
     text-transform: uppercase;
     letter-spacing: 0.15em;
-    padding: var(--spacing-large) 0 var(--spacing-small);
+    padding: 0.75em 0 var(--spacing-small);
     text-align: center;
     position: relative;
 }
@@ -516,7 +516,7 @@ body.about .about-lines {
     margin: 0 0 var(--spacing-small);
     text-transform: uppercase;
     letter-spacing: 0.15em;
-    padding: var(--spacing-large) 0 var(--spacing-small);
+    padding: 0.75em 0 var(--spacing-small);
     text-align: center;
     position: relative;
 }


### PR DESCRIPTION
## Summary
- shrink heading padding to 0.75em above the text

## Testing
- `pytest -q`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6884cdf1408c832da4aa6fab20253030