### PR TITLE
Add mobile baseline ruler

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -61,5 +61,6 @@
         </div>
     </footer>
     <script src="../transition.js"></script>
+    <script src="../ruler.js"></script>
 </body>
 </html>

--- a/events/index.html
+++ b/events/index.html
@@ -82,5 +82,6 @@
         </div>
     </footer>
     <script src="../transition.js"></script>
+    <script src="../ruler.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -94,5 +94,6 @@
         </div>
     </footer>
     <script src="transition.js"></script>
+    <script src="ruler.js"></script>
 </body>
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -62,5 +62,6 @@
         </div>
     </footer>
     <script src="../transition.js"></script>
+    <script src="../ruler.js"></script>
 </body>
 </html>

--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -119,6 +119,7 @@
         </div>
     </footer>
     <script src="../../transition.js"></script>
+    <script src="../../ruler.js"></script>
     <script src="../../back-link.js"></script>
 </body>
 </html>

--- a/ruler.js
+++ b/ruler.js
@@ -1,0 +1,14 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const button = document.createElement('button');
+  button.className = 'ruler-toggle';
+  button.textContent = 'Ruler';
+  document.body.appendChild(button);
+
+  const overlay = document.createElement('div');
+  overlay.className = 'baseline-ruler-overlay';
+  document.body.appendChild(overlay);
+
+  button.addEventListener('click', () => {
+    document.body.classList.toggle('ruler-active');
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1034,3 +1034,39 @@ body.fade-out {
         transform: none;
     }
 }
+
+/* Baseline ruler overlay for development */
+.baseline-ruler-overlay {
+    pointer-events: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 9998;
+    background-image: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.3) 0,
+        rgba(255, 255, 255, 0.3) 1px,
+        transparent 1px,
+        transparent 1.6em
+    );
+    display: none;
+}
+
+.ruler-toggle {
+    position: fixed;
+    bottom: 1em;
+    right: 1em;
+    z-index: 9999;
+    padding: 0.5em 0.8em;
+    font-size: 0.9em;
+    background: rgba(255, 255, 255, 0.2);
+    border: none;
+    color: #ffffff;
+    border-radius: 4px;
+}
+
+.ruler-active .baseline-ruler-overlay {
+    display: block;
+}

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -84,6 +84,7 @@
         </div>
     </footer>
     <script src="../../transition.js"></script>
+    <script src="../../ruler.js"></script>
     <script src="../../back-link.js"></script>
 </body>
 </html>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -72,6 +72,7 @@
         </div>
     </footer>
     <script src="../../transition.js"></script>
+    <script src="../../ruler.js"></script>
     <script src="../../back-link.js"></script>
 </body>
 </html>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -84,6 +84,7 @@
         </div>
     </footer>
     <script src="../../transition.js"></script>
+    <script src="../../ruler.js"></script>
     <script src="../../back-link.js"></script>
 </body>
 </html>

--- a/works/index.html
+++ b/works/index.html
@@ -85,5 +85,6 @@
         </div>
     </footer>
     <script src="../transition.js"></script>
+    <script src="../ruler.js"></script>
 </body>
 </html>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -95,6 +95,7 @@
         </div>
     </footer>
     <script src="../../transition.js"></script>
+    <script src="../../ruler.js"></script>
     <script src="../../back-link.js"></script>
 </body>
 </html>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -69,6 +69,7 @@
         </div>
     </footer>
     <script src="../../transition.js"></script>
+    <script src="../../ruler.js"></script>
     <script src="../../back-link.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `ruler.js` to toggle a baseline overlay
- include ruler script on every page
- style the baseline ruler in CSS for development use

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e0d86f48832d97ea372f1799089b