### PR TITLE
Add movable single-line ruler

### DIFF
--- a/ruler.js
+++ b/ruler.js
@@ -6,7 +6,48 @@ window.addEventListener('DOMContentLoaded', () => {
 
   const overlay = document.createElement('div');
   overlay.className = 'baseline-ruler-overlay';
+  const line = document.createElement('div');
+  line.className = 'baseline-ruler-line';
+  overlay.appendChild(line);
   document.body.appendChild(overlay);
+
+  let isDragging = false;
+
+  const moveLine = (y) => {
+    line.style.top = `${y}px`;
+  };
+
+  line.addEventListener('mousedown', (e) => {
+    isDragging = true;
+    moveLine(e.clientY);
+    e.preventDefault();
+  });
+
+  window.addEventListener('mousemove', (e) => {
+    if (isDragging) {
+      moveLine(e.clientY);
+    }
+  });
+
+  window.addEventListener('mouseup', () => {
+    isDragging = false;
+  });
+
+  line.addEventListener('touchstart', (e) => {
+    isDragging = true;
+    moveLine(e.touches[0].clientY);
+    e.preventDefault();
+  });
+
+  window.addEventListener('touchmove', (e) => {
+    if (isDragging) {
+      moveLine(e.touches[0].clientY);
+    }
+  });
+
+  window.addEventListener('touchend', () => {
+    isDragging = false;
+  });
 
   button.addEventListener('click', () => {
     document.body.classList.toggle('ruler-active');

--- a/style.css
+++ b/style.css
@@ -1044,14 +1044,18 @@ body.fade-out {
     right: 0;
     bottom: 0;
     z-index: 9998;
-    background-image: repeating-linear-gradient(
-        to bottom,
-        rgba(255, 255, 255, 0.3) 0,
-        rgba(255, 255, 255, 0.3) 1px,
-        transparent 1px,
-        transparent 1.6em
-    );
     display: none;
+}
+
+.baseline-ruler-line {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: rgba(255, 255, 255, 0.5);
+    pointer-events: auto;
+    cursor: ns-resize;
 }
 
 .ruler-toggle {


### PR DESCRIPTION
## Summary
- convert baseline ruler overlay to single movable line
- allow dragging with mouse or touch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e206b9c8832d8f00ec8dd60c6c2e