### PR TITLE
Fix past events spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -854,8 +854,8 @@ main > section:first-of-type > .works-title:first-child {
 .events-separator {
     border: 0;
     border-top: 1px solid #555555;
-    margin: 1em 0;
-    margin: var(--spacing-large) 0;
+    margin: 1em 0 0;
+    margin: var(--spacing-large) 0 0;
 }
 .events-separator:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
## Summary
- remove bottom margin from `.events-separator` so `Past Events` aligns with the upcoming section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e2362254832db31ab51e1cfbde60