### PR TITLE
Unify header spacing with custom property

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,6 +4,7 @@
     --separator-width: 50%;
     --spacing-large: 1em;
     --spacing-small: 0.5em;
+    --header-spacing: 1.25em;
 }
 
 html {
@@ -49,7 +50,7 @@ header::after {
 header .container {
     display: flex;
     align-items: center;
-    padding: 1.15em;
+    padding: var(--header-spacing) 2vw;
     letter-spacing: 0.05em;
     position: relative;
 }
@@ -234,7 +235,7 @@ header::after {
 header .container {
     display: flex;
     align-items: center;
-    padding: 1.25em 2vw;
+    padding: var(--header-spacing) 2vw;
     letter-spacing: 0.05em;
     position: relative;
 }
@@ -322,7 +323,7 @@ main {
 
 body.home main {
     /* Match the spacing below the header for pages with hero sections */
-    padding-top: var(--spacing-small);
+    padding-top: var(--header-spacing);
 }
 .logo img {
     width: 60px;
@@ -379,7 +380,7 @@ h1 {
  * immediately follows the opening section in main.
  */
 main > section:first-of-type > h1:first-child {
-    margin-top: 0;
+    margin-top: var(--header-spacing);
 }
 h1::after {
     content: "";
@@ -690,7 +691,7 @@ body.about .about-lines {
 }
 
 main > section:first-of-type > .works-title:first-child {
-    margin-top: 0;
+    margin-top: var(--header-spacing);
 }
 
 .works-title::after {
@@ -984,9 +985,10 @@ body.fade-out {
 @media (max-width: 600px) {
     :root {
         --header-height: 70px;
+        --header-spacing: 0.6em;
     }
     header .container {
-        padding: 0.6em 4vw;
+        padding: var(--header-spacing) 4vw;
     }
     .container {
         padding-left: 4vw;

--- a/transition.js
+++ b/transition.js
@@ -1,5 +1,15 @@
+function updateHeaderHeight(){
+  const header=document.querySelector("header");
+  if(header){
+    document.documentElement.style.setProperty("--header-height", header.offsetHeight + "px");
+  }
+}
+
+window.addEventListener("resize", updateHeaderHeight);
+
 window.addEventListener('DOMContentLoaded', () => {
   document.body.classList.add('fade-in');
+  updateHeaderHeight();
   const anchors = document.querySelectorAll('a[href]');
   anchors.forEach(a => {
     const href = a.getAttribute('href');


### PR DESCRIPTION
## Summary
- add `--header-spacing` variable in `style.css`
- use the variable for `header .container` padding on desktop and mobile
- align `body.home main` padding and first heading margin with `--header-spacing`
- compute `--header-height` dynamically in `transition.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e497a664832da68f35f86accd89b