### PR TITLE
Fix Reach.Touch spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -644,7 +644,7 @@ body.about .about-lines {
     margin-bottom: 0.5em;
 }
 .reach-touch .about-text {
-    margin-bottom: var(--spacing-large);
+    margin-bottom: 1.5em; /* match spacing of works list */
     transition: transform 0.3s ease, background-color 0.3s ease;
 }
 .reach-touch .about-text:last-child {


### PR DESCRIPTION
## Summary
- increase `about-text` spacing inside Reach.Touch project to match layout of works index

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884facc7ee8832daf4a4d3927e6dfd2