### PR TITLE
Fix Reach.Touch. instrumentation spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -647,6 +647,9 @@ body.about .about-lines {
     margin-bottom: 1.5em; /* match spacing of works list */
     transition: transform 0.3s ease, background-color 0.3s ease;
 }
+.reach-touch .about-text:has(+ hr[class*="works-separator"]) {
+    margin-bottom: 1em;
+}
 .reach-touch .about-text:last-child {
     margin-bottom: 0;
 }


### PR DESCRIPTION
## Summary
- adjust about-text spacing before separators on Reach.Touch. project page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884fba75ca0832d8c3f7f8d00bfdc93