### PR TITLE
Fix Reach.Touch separator spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -648,7 +648,12 @@ body.about .about-lines {
     transition: transform 0.3s ease, background-color 0.3s ease;
 }
 .reach-touch .about-text:has(+ hr[class*="works-separator"]) {
-    margin-bottom: 1em;
+    margin-bottom: 0.5em;
+}
+
+.reach-touch hr[class*="works-separator"] {
+    margin-top: 0;
+    margin-bottom: 0.5em;
 }
 .reach-touch .about-text:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
## Summary
- reduce the bottom margin before separator lines on the Reach.Touch page
- ensure separators themselves have reduced spacing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884fd5bdd1c832da937bd883efadf3b