### PR TITLE
Fix Reach.Touch separator spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -653,7 +653,7 @@ body.about .about-lines {
 
 .reach-touch hr[class*="works-separator"] {
     margin-top: 0;
-    margin-bottom: 0.5em;
+    margin-bottom: var(--spacing-large);
 }
 .reach-touch .about-text:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
## Summary
- fine-tune separator spacing on the Reach.Touch page so bottom margin matches other works

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884fe7cb970832dbcede84132fbbdaf