### PR TITLE
Fix Reach.Touch spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -634,6 +634,9 @@ body.about .about-lines {
 .reach-touch .about-text:has(+ hr[class*="works-separator"]) {
     margin-bottom: var(--spacing-large);
 }
+.reach-touch hr[class*="works-separator"] + p.regular {
+    margin-top: var(--spacing-large);
+}
 .reach-touch .about-text:last-child {
     margin-bottom: 0;
 }


### PR DESCRIPTION
## Summary
- ensure consistent vertical space around separator lines on the Reach.Touch project page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688506bff534832db468a70420edd372