### PR TITLE
Implement gray cross cursor

### DIFF
--- a/logos/custom-cursor.svg
+++ b/logos/custom-cursor.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <line x1="8" y1="0" x2="8" y2="16" stroke="#555555" stroke-width="1" stroke-linecap="square"/>
+  <line x1="0" y1="8" x2="16" y2="8" stroke="#555555" stroke-width="1" stroke-linecap="square"/>
+</svg>

--- a/style.css
+++ b/style.css
@@ -1080,3 +1080,8 @@ body.fade-out {
 .ruler-active .baseline-ruler-overlay {
     display: block;
 }
+
+/* Custom gray cross cursor */
+body {
+    cursor: url('logos/custom-cursor.svg') 8 8, crosshair;
+}


### PR DESCRIPTION
## Summary
- add a small SVG crosshair pointer
- apply the custom cursor site-wide via CSS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688510697fc4832d9fd48954054457bc