### PR TITLE
Fix navigation links not clickable after custom cursor

### DIFF
--- a/style.css
+++ b/style.css
@@ -426,6 +426,7 @@ a, .link {
     color: #ffffff;
     font-weight: 400;
     text-decoration: none;
+    cursor: pointer;
 }
 a:hover, .link:hover {
     text-decoration: underline;


### PR DESCRIPTION
## Summary
- ensure anchor elements keep a pointer cursor on hover so navigation remains usable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68851125fb08832d97236b3e4c7b6558