### PR TITLE
Fix spacing after works separator

### DIFF
--- a/style.css
+++ b/style.css
@@ -880,6 +880,11 @@ main > section:first-of-type > .works-title:first-child {
     margin-bottom: 0;
 }
 
+/* Remove extra top space before program notes */
+.works-separator + p.italic {
+    margin-top: 0;
+}
+
 /* Half-length separator used on specific project pages */
 .works-separator-half {
     border: 0;


### PR DESCRIPTION
## Summary
- ensure program notes have no extra top margin after a works separator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885184aaa98832d8b097f20d281fda7