### PR TITLE
Fix spacing around SoundCloud sections

### DIFF
--- a/style.css
+++ b/style.css
@@ -786,7 +786,7 @@ main > section:first-of-type > .works-title:first-child {
 }
 
 .soundcloud-player {
-    margin: 0.5em 0;
+    margin: var(--spacing-small) 0;
 }
 
 .events-list {
@@ -907,6 +907,11 @@ main > section:first-of-type > .works-title:first-child {
 }
 .works-separator-small:last-child {
     margin-bottom: 0;
+}
+
+/* Match spacing above and below the reduced separators */
+hr.works-separator-small + .works-details {
+    margin-top: var(--spacing-small);
 }
 
 /* Ensure consistent spacing when a separator is followed by a heading */


### PR DESCRIPTION
## Summary
- use spacing variables for SoundCloud player margins
- add rule so separator spacing is consistent with commission/support lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68851b937d28832d8709a6e5e2d52cd6