### PR TITLE
Remove custom cursor

### DIFF
--- a/logos/custom-cursor.svg
+++ b/logos/custom-cursor.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 27.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 36 36" style="enable-background:new 0 0 36 36;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:none;stroke:#000000;stroke-miterlimit:10;}
-</style>
-<line class="st0" x1="12.2" y1="1.2" x2="13.5" y2="30.7"/>
-</svg>

--- a/style.css
+++ b/style.css
@@ -61,7 +61,7 @@ header .container {
     width: 24px;
     height: 18px;
     position: relative;
-    cursor: url('logos/custom-cursor.svg?v=1') 8 8, pointer;
+    cursor: pointer;
     margin-left: auto;
 }
 .menu-icon::before {
@@ -236,7 +236,7 @@ header .container {
     width: 24px;
     height: 18px;
     position: relative;
-    cursor: url('logos/custom-cursor.svg?v=1') 8 8, pointer;
+    cursor: pointer;
     margin-left: auto;
 }
 .menu-icon::before {
@@ -426,7 +426,7 @@ a, .link {
     color: #ffffff;
     font-weight: 400;
     text-decoration: none;
-    cursor: url('logos/custom-cursor.svg?v=1') 8 8, pointer;
+    cursor: pointer;
 }
 a:hover, .link:hover {
     text-decoration: underline;
@@ -1102,7 +1102,4 @@ body.fade-out {
     display: block;
 }
 
-/* Custom gray cross cursor */
-body {
-    cursor: url('logos/custom-cursor.svg?v=1') 8 8, crosshair;
-}
+


### PR DESCRIPTION
## Summary
- remove `custom-cursor.svg` asset
- revert cursor styling to defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68851eb50b90832db8bd21084704348a