### PR TITLE
Fix mobile navigation position

### DIFF
--- a/style.css
+++ b/style.css
@@ -183,13 +183,6 @@ h1 {
     text-align: center;
     position: relative;
 }
-h1:root {
-    --header-height: 100px;
-    --footer-height: 100px;
-    --separator-width: 50%;
-    --spacing-large: 1em;
-    --spacing-small: 0.5em;
-}
 
 html {
     scroll-padding-top: var(--header-height);
@@ -437,7 +430,7 @@ header nav a:hover {
 header nav {
     display: none;
     position: absolute;
-    top: 101px;
+    top: calc(var(--header-height) + 1px);
     left: 0em;
     right: 2.5em;
     margin-left: 0;


### PR DESCRIPTION
## Summary
- removed mistakenly duplicated `:root` variables from `h1:root`
- align nav dropdown with header height using CSS variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885550a0214832db34363e03f6e2dcd