### PR TITLE
Add mobile styles for header pseudo-elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -1047,3 +1047,29 @@ body.fade-out {
 }
 
 
+
+@media only screen and (max-width: 600px) {
+    header::after {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 100%;
+        border-bottom: 1px solid #555555;
+    }
+
+    header nav::after {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 100%;
+        height: 50px;
+        pointer-events: none;
+        border-top: 20px solid #000000;
+        border-bottom: 1px solid #555;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add mobile-specific CSS for `header::after` and `header nav::after` to fill width on small screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885593128e0832dabf02cab4ce69a2f