### PR TITLE
Center mobile nav items

### DIFF
--- a/style.css
+++ b/style.css
@@ -495,14 +495,20 @@ header nav a.active::after {
         left: 0;
         right: 0;
         flex-direction: column;
-        align-items: flex-start;
+        align-items: center;
         padding: 0 1em;
     }
 
     header nav a {
         display: block;
-        padding: 0.75em 0;
+        padding: var(--spacing-large) 0;
+        margin-bottom: var(--spacing-large);
         width: 100%;
+        text-align: center;
+    }
+
+    header nav a:last-child {
+        margin-bottom: 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- center-align header navigation links on mobile
- use spacing variable for padding and margin between mobile navigation links

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68855b0f1088832d8f75863e127cf0b3