### PR TITLE
Fix header centering while keeping section padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -595,7 +595,11 @@ img {
 
 section {
     position: relative;
-    padding-right: 0em;
+    padding-right: 1em;
+}
+
+section > h1 {
+    margin-right: -1em;
 }
 
 section::after {


### PR DESCRIPTION
## Summary
- restore padding-right to sections so the vertical line has room
- offset section headings with negative margin so they remain centered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855f94a174832dabb8a35a85e40d98