### PR TITLE
Fix mobile hamburger hover state

### DIFF
--- a/style.css
+++ b/style.css
@@ -76,7 +76,7 @@ header .container {
     background-color: transparent;
     transition: background-color 0.3s ease;
 }
-.menu-icon:hover::before {
+.menu-toggle:not(:checked) + .menu-icon:hover::before {
     /* Slightly brighter hover background */
     background-color: rgba(255, 255, 255, 0.12);
 }
@@ -244,7 +244,7 @@ header .container {
     background-color: transparent;
     transition: background-color 0.3s ease;
 }
-.menu-icon:hover::before {
+.menu-toggle:not(:checked) + .menu-icon:hover::before {
     /* Slightly brighter hover background */
     background-color: rgba(255, 255, 255, 0.12);
 }


### PR DESCRIPTION
## Summary
- fix sticky circle background after closing hamburger menu on touch devices

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688564ece15c832d92b7c20dc6ea4c86