### PR TITLE
Reduce hero title size on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1104,5 +1104,10 @@ body.fade-out {
         border-right: 1em solid #000000;
         border-left: 1em solid #000000;
     }
+
+    /* Reduce hero title size so it fits on one line */
+    .hero h1 {
+        font-size: 1.5em;
+    }
 }
 


### PR DESCRIPTION
## Summary
- tweak style for `.hero h1` so that the hero title fits on mobile screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688567fd4144832d983b694531b43296