### PR TITLE
Resize hero and about images

### DIFF
--- a/style.css
+++ b/style.css
@@ -525,11 +525,12 @@ img {
     margin-right: auto;
 }
 .placeholder-image {
-    width: 100%;
+    width: 40%;
+    max-width: 400px;
     height: auto;
     margin-top: 1em;
-    margin-left: 0;
-    margin-right: 0;
+    margin-left: auto;
+    margin-right: auto;
 }
 .logo img,
 .footer-icons img {
@@ -964,9 +965,9 @@ hr[class*="separator"] + h3 {
 }
 
 .hero img {
-    width: 100%;
-    height: calc(100vh - var(--header-height) - var(--footer-height));
-    max-height: none;
+    width: 40%;
+    max-width: 400px;
+    height: auto;
     object-fit: cover;
     margin-top: 0;
     margin-bottom: 0;


### PR DESCRIPTION
## Summary
- reduce image size for hero and about sections

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd753a84c832db7b52795da9d0ff9