### PR TITLE
Add portraits section and update nav

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -21,9 +21,11 @@
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>
+            <a href="/" class="link">Home</a>
             <a href="/about/" class="link active">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link">Works</a>
+            <a href="/portraits/" class="link">Portraits</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/events/index.html
+++ b/events/index.html
@@ -21,9 +21,11 @@
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>
+            <a href="/" class="link">Home</a>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link">Works</a>
+            <a href="/portraits/" class="link">Portraits</a>
             <a href="/events/" class="link active">Events</a>
         </nav>
         </div>

--- a/index.html
+++ b/index.html
@@ -58,9 +58,11 @@
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>
+            <a href="/" class="link active">Home</a>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link">Works</a>
+            <a href="/portraits/" class="link">Portraits</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/portraits/index.html
+++ b/portraits/index.html
@@ -1,19 +1,20 @@
 <!DOCTYPE html>
-<html lang="it">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Assume - Leonardo Matteucci</title>
-    <link rel="icon" href="../../logos/lm-logo-favicon.svg" type="image/svg+xml">
+    <meta name="description" content="Portrait images of composer Leonardo Matteucci.">
+    <title>Portraits - Leonardo Matteucci</title>
+    <link rel="icon" href="../logos/lm-logo-favicon.svg" type="image/svg+xml">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../style.css">
 </head>
-<body>
+<body class="portraits">
     <header>
         <div class="container">
         <div class="logo">
             <a href="/" title="Home">
-                <img src="../../logos/lm-logo-favicon.svg" alt="logo">
+                <img src="../logos/lm-logo-favicon.svg" alt="home">
             </a>
         </div>
         <a href="/" title="Home" class="tagline">LEONARDO MATTEUCCI</a>
@@ -23,56 +24,45 @@
             <a href="/" class="link">Home</a>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
-            <a href="/works/" class="link active">Works</a>
-            <a href="/portraits/" class="link">Portraits</a>
+            <a href="/works/" class="link">Works</a>
+            <a href="/portraits/" class="link active">Portraits</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>
     </header>
-<main>
-    <section>
-    <p class="works-title">Assume (2025)</p>
-    <p class="works-details align-center duration">15′</p>
-    <ul class="instrumentation-list large-margin">
-        <li>Piano</li>
-        <li>Flute</li>
-        <li>Cello</li>
-        <li>
-            Electronics: fixed media (5-channel)
-            <ul class="gear-list">
-                <li>3 audio exciters</li>
-                <li>2 cardioid condenser microphones</li>
-                <li>2 clip-on microphones</li>
-            </ul>
-        </li>
-    </ul>
-    <p class="works-premiere premiere">Premiere: 28 November 2025, KULTUM, [imCubus], Graz</p>
-    <hr class="works-separator">
-    </section>
+    <main>
+        <section>
+            <h1>Portraits</h1>
+            <div class="portrait-grid">
+                <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
+                <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
+                <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
+            </div>
+        </section>
     </main>
     <footer>
         <div class="container">
             <p>&copy; 2025 Leonardo Matteucci</p>
             <div class="footer-icons">
                 <a href="https://www.youtube.com/@leonardo_matteucci" title="YouTube" target="_blank">
-                    <img src="../../logos/youtube-logo_white.svg" alt="YouTube">
+                    <img src="../logos/youtube-logo_white.svg" alt="YouTube">
                 </a>
                 <a href="https://soundcloud.com/leonardo_matteucci" title="SoundCloud" target="_blank">
-                    <img src="../../logos/soundcloud-logo_white.svg" alt="SoundCloud">
+                    <img src="../logos/soundcloud-logo_white.svg" alt="SoundCloud">
                 </a>
                 <a href="https://www.instagram.com/leonardo_matteucci_ig" title="Instagram" target="_blank">
-                    <img src="../../logos/instagram-logo_white.svg" alt="Instagram">
+                    <img src="../logos/instagram-logo_white.svg" alt="Instagram">
                 </a>
                 <a href="https://www.facebook.com/leonardo.matteucci.fb" title="Facebook" target="_blank">
-                    <img src="../../logos/facebook-logo_white.svg" alt="Facebook">
+                    <img src="../logos/facebook-logo_white.svg" alt="Facebook">
                 </a>
                 <a href="mailto:leonardo.matteucci@icloud.com" title="Personal Email" target="_blank">
-                    <img src="../../logos/email-logo_white.svg" alt="Email">
+                    <img src="../logos/email-logo_white.svg" alt="Email">
                 </a>
             </div>
         </div>
     </footer>
-    <script src="../../transition.js"></script>
-    <script src="../../ruler.js"></script>
+    <script src="../transition.js"></script>
+    <script src="../ruler.js"></script>
 </body>
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -21,9 +21,11 @@
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>
+            <a href="/" class="link">Home</a>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link active">Projects</a>
             <a href="/works/" class="link">Works</a>
+            <a href="/portraits/" class="link">Portraits</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -20,9 +20,11 @@
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>
+            <a href="/" class="link">Home</a>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link active">Projects</a>
             <a href="/works/" class="link">Works</a>
+            <a href="/portraits/" class="link">Portraits</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -31,6 +31,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://www.leonardomatteucci.com/portraits/</loc>
+    <lastmod>2024-06-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://www.leonardomatteucci.com/projects/reach-touch/</loc>
     <lastmod>2024-06-30</lastmod>
     <changefreq>monthly</changefreq>

--- a/style.css
+++ b/style.css
@@ -1118,3 +1118,14 @@ body.fade-out {
     }
 }
 
+
+.portrait-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: var(--spacing-large);
+}
+.portrait-grid img {
+    width: 100%;
+    height: auto;
+    display: block;
+}

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -20,9 +20,11 @@
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>
+            <a href="/" class="link">Home</a>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
+            <a href="/portraits/" class="link">Portraits</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -20,9 +20,11 @@
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>
+            <a href="/" class="link">Home</a>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
+            <a href="/portraits/" class="link">Portraits</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/works/index.html
+++ b/works/index.html
@@ -21,9 +21,11 @@
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>
+            <a href="/" class="link">Home</a>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
+            <a href="/portraits/" class="link">Portraits</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -20,9 +20,11 @@
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>
+            <a href="/" class="link">Home</a>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
+            <a href="/portraits/" class="link">Portraits</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -20,9 +20,11 @@
         <input type="checkbox" id="menu-toggle" class="menu-toggle">
         <label for="menu-toggle" class="menu-icon" title="Menu"><span></span><span></span><span></span></label>
         <nav>
+            <a href="/" class="link">Home</a>
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
+            <a href="/portraits/" class="link">Portraits</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>


### PR DESCRIPTION
## Summary
- add `Portraits` page with placeholder images
- include `Home` and `Portraits` links in the main navigation on all pages
- update sitemap
- add portrait grid styling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cdf2f8784832d955e373ac964f997