### PR TITLE
Add photo credits

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -38,6 +38,7 @@
                 <p>He studied composition with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> in Turin (2019–2021) and <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> in Fermo (2021–2023), and is currently pursuing a Master’s degree under <a href="https://fr.wikipedia.org/wiki/Franck_Bedrossian" target="_blank">Franck Bedrossian</a> at <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
             </div>
             <img src="../graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
+            <p class="photo-credit gray">&copy; Lorenzo Chiacchieroni</p>
         </section>
     </main>
     <footer>

--- a/index.html
+++ b/index.html
@@ -71,6 +71,7 @@
     <main>
         <section class="hero">
             <img src="/graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
+            <p class="photo-credit gray">&copy; Lorenzo Chiacchieroni</p>
         </section>
     </main>
     <footer>

--- a/style.css
+++ b/style.css
@@ -545,6 +545,14 @@ img {
     margin-left: auto;
     margin-right: auto;
 }
+.photo-credit {
+    width: 40%;
+    max-width: 700px;
+    margin: 0.5em auto 0;
+    text-align: right;
+    font-size: 0.8em;
+    color: #bbbbbb;
+}
 .logo img,
 .footer-icons img {
     margin-top: 0;


### PR DESCRIPTION
## Summary
- credit photographer for hero images on home and about pages
- style photo credit text so it matches site footer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d37d9d30c832da49bc3bc3190fdb3