### PR TITLE
Introduce press kit page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -25,7 +25,7 @@
             <a href="/about/" class="link active">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link">Works</a>
-            <a href="/portraits/" class="link">Portraits</a>
+            <a href="/press-kit/" class="link">Press Kit</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/events/index.html
+++ b/events/index.html
@@ -25,7 +25,7 @@
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link">Works</a>
-            <a href="/portraits/" class="link">Portraits</a>
+            <a href="/press-kit/" class="link">Press Kit</a>
             <a href="/events/" class="link active">Events</a>
         </nav>
         </div>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link">Works</a>
-            <a href="/portraits/" class="link">Portraits</a>
+            <a href="/press-kit/" class="link">Press Kit</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Portrait images of composer Leonardo Matteucci.">
-    <title>Portraits - Leonardo Matteucci</title>
+    <meta name="description" content="Press materials for composer Leonardo Matteucci, including a short biography and portrait photos.">
+    <title>Press Kit - Leonardo Matteucci</title>
     <link rel="icon" href="../logos/lm-logo-favicon.svg" type="image/svg+xml">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
-<body class="portraits">
+<body class="press-kit">
     <header>
         <div class="container">
         <div class="logo">
@@ -25,19 +25,44 @@
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link">Works</a>
-            <a href="/portraits/" class="link active">Portraits</a>
+            <a href="/press-kit/" class="link active">Press Kit</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>
     </header>
     <main>
         <section>
-            <h1>Portraits</h1>
-            <div class="portrait-grid">
-                <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
-                <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
-                <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
-            </div>
+            <h1>Press Kit</h1>
+            <ul class="works-list press-list">
+                <li>
+                    <details class="press-item" open>
+                        <summary class="list-title">Short Biography (Press Version)</summary>
+                        <p class="works-details">Leonardo Matteucci (*2000) is an Italian composer based in Graz, Austria. His works explore the intersection of acoustic gesture and electronic transformation, inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation. His works have been performed by ensembles such as Opificio Sonoro, Quartetto Maurice, and Collettivo_21. He is currently pursuing his Master’s degree in Composition at Kunstuniversität Graz under Franck Bedrossian.</p>
+                    </details>
+                </li>
+                <li>
+                    <details class="press-item">
+                        <summary class="list-title">Portraits</summary>
+                        <div class="portrait-grid">
+                            <figure>
+                                <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
+                                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+                                <a href="../graphics/placeholder.svg" download>Download</a>
+                            </figure>
+                            <figure>
+                                <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
+                                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+                                <a href="../graphics/placeholder.svg" download>Download</a>
+                            </figure>
+                            <figure>
+                                <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
+                                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+                                <a href="../graphics/placeholder.svg" download>Download</a>
+                            </figure>
+                        </div>
+                    </details>
+                </li>
+            </ul>
         </section>
     </main>
     <footer>

--- a/projects/index.html
+++ b/projects/index.html
@@ -25,7 +25,7 @@
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link active">Projects</a>
             <a href="/works/" class="link">Works</a>
-            <a href="/portraits/" class="link">Portraits</a>
+            <a href="/press-kit/" class="link">Press Kit</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -24,7 +24,7 @@
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link active">Projects</a>
             <a href="/works/" class="link">Works</a>
-            <a href="/portraits/" class="link">Portraits</a>
+            <a href="/press-kit/" class="link">Press Kit</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -31,7 +31,7 @@
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://www.leonardomatteucci.com/portraits/</loc>
+    <loc>https://www.leonardomatteucci.com/press-kit/</loc>
     <lastmod>2024-06-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>

--- a/style.css
+++ b/style.css
@@ -712,6 +712,39 @@ body.about .about-lines {
     margin-bottom: 0;
 }
 
+/* Press kit list styled like works list */
+.press-list {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+
+.press-list li {
+    margin-bottom: 1.5em;
+    padding-left: 1em;
+    border-left: 3px solid #555555;
+    transition: transform 0.3s ease, background-color 0.3s ease;
+}
+
+.press-list li:last-child {
+    margin-bottom: 0;
+}
+
+.press-list li:hover {
+    transform: translateX(5px);
+    background-color: rgba(255, 255, 255, 0.12);
+}
+
+.press-item > summary {
+    list-style: none;
+    cursor: pointer;
+    font-weight: 300;
+}
+
+.press-item > summary::-webkit-details-marker {
+    display: none;
+}
+
 /* Titles for entries in the Works and Projects index pages */
 .list-title {
     display: block;
@@ -1140,5 +1173,16 @@ body.fade-out {
 .portrait-grid img {
     width: 100%;
     height: auto;
+    display: block;
+}
+.portrait-grid figure {
+    margin: 0;
+    text-align: center;
+}
+
+.portrait-grid figcaption,
+.portrait-grid a {
+    font-size: 0.9em;
+    margin-top: 0.3em;
     display: block;
 }

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -24,7 +24,7 @@
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
-            <a href="/portraits/" class="link">Portraits</a>
+            <a href="/press-kit/" class="link">Press Kit</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -24,7 +24,7 @@
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
-            <a href="/portraits/" class="link">Portraits</a>
+            <a href="/press-kit/" class="link">Press Kit</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -24,7 +24,7 @@
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
-            <a href="/portraits/" class="link">Portraits</a>
+            <a href="/press-kit/" class="link">Press Kit</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/works/index.html
+++ b/works/index.html
@@ -25,7 +25,7 @@
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
-            <a href="/portraits/" class="link">Portraits</a>
+            <a href="/press-kit/" class="link">Press Kit</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -24,7 +24,7 @@
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
-            <a href="/portraits/" class="link">Portraits</a>
+            <a href="/press-kit/" class="link">Press Kit</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -24,7 +24,7 @@
             <a href="/about/" class="link">About</a>
             <a href="/projects/" class="link">Projects</a>
             <a href="/works/" class="link active">Works</a>
-            <a href="/portraits/" class="link">Portraits</a>
+            <a href="/press-kit/" class="link">Press Kit</a>
             <a href="/events/" class="link">Events</a>
         </nav>
         </div>


### PR DESCRIPTION
## Summary
- rename the Portraits page to `press-kit`
- add links and navigation for the new Press Kit page
- implement dropdown biography and portraits section
- style press kit items and portrait captions
- update sitemap accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d37727b4c832db866aebf94f4e28b