### PR TITLE
Overlay photo credit on hero images

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -37,8 +37,10 @@
                 <p><a href="/">Leonardo Matteucci</a> is a composer exploring inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation.</p>
                 <p>He studied composition with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> in Turin (2019–2021) and <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> in Fermo (2021–2023), and is currently pursuing a Master’s degree under <a href="https://fr.wikipedia.org/wiki/Franck_Bedrossian" target="_blank">Franck Bedrossian</a> at <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
             </div>
-            <img src="../graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
-            <p class="photo-credit gray">&copy; Lorenzo Chiacchieroni</p>
+            <div class="image-overlay">
+                <img src="../graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
+                <p class="photo-credit gray">&copy; Lorenzo Chiacchieroni</p>
+            </div>
         </section>
     </main>
     <footer>

--- a/index.html
+++ b/index.html
@@ -70,8 +70,10 @@
 
     <main>
         <section class="hero">
-            <img src="/graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
-            <p class="photo-credit gray">&copy; Lorenzo Chiacchieroni</p>
+            <div class="image-overlay">
+                <img src="/graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
+                <p class="photo-credit gray">&copy; Lorenzo Chiacchieroni</p>
+            </div>
         </section>
     </main>
     <footer>

--- a/style.css
+++ b/style.css
@@ -553,6 +553,26 @@ img {
     font-size: 0.8em;
     color: #bbbbbb;
 }
+
+.image-overlay {
+    position: relative;
+    display: inline-block;
+}
+
+.image-overlay img {
+    display: block;
+}
+
+.image-overlay .photo-credit {
+    position: absolute;
+    bottom: 0.3em;
+    right: 0.3em;
+    width: auto;
+    max-width: none;
+    margin: 0;
+    padding: 0.2em 0.4em;
+    background: rgba(0, 0, 0, 0.6);
+}
 .logo img,
 .footer-icons img {
     margin-top: 0;


### PR DESCRIPTION
## Summary
- overlay the photographer credit on hero images
- refactor index and about pages to wrap the hero image and caption
- support overlay styling in CSS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d38fccd3c832d9eb6f8faaf052fcf