### PR TITLE
Add dual download buttons for press images

### DIFF
--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -47,17 +47,26 @@
                             <figure>
                                 <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
-                                <a href="../graphics/placeholder.svg" download>Download</a>
+                                <div class="download-buttons">
+                                    <a href="../graphics/placeholder.svg" download class="download-button gray">web</a>
+                                    <a href="../graphics/placeholder.svg" download class="download-button gray">high-res</a>
+                                </div>
                             </figure>
                             <figure>
                                 <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
-                                <a href="../graphics/placeholder.svg" download>Download</a>
+                                <div class="download-buttons">
+                                    <a href="../graphics/placeholder.svg" download class="download-button gray">web</a>
+                                    <a href="../graphics/placeholder.svg" download class="download-button gray">high-res</a>
+                                </div>
                             </figure>
                             <figure>
                                 <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
-                                <a href="../graphics/placeholder.svg" download>Download</a>
+                                <div class="download-buttons">
+                                    <a href="../graphics/placeholder.svg" download class="download-button gray">web</a>
+                                    <a href="../graphics/placeholder.svg" download class="download-button gray">high-res</a>
+                                </div>
                             </figure>
                         </div>
                     </details>

--- a/style.css
+++ b/style.css
@@ -1214,3 +1214,23 @@ body.fade-out {
     margin-top: 0.3em;
     display: block;
 }
+
+/* Download button styles for press kit portraits */
+.download-buttons {
+    display: flex;
+    justify-content: center;
+    gap: 0.5em;
+}
+
+.download-button {
+    border: 1px solid #555555;
+    padding: 0.2em 0.6em;
+    border-radius: 3px;
+    color: #bbbbbb;
+    text-decoration: none;
+    font-size: 0.9em;
+}
+
+.download-button:hover {
+    background-color: rgba(255, 255, 255, 0.12);
+}


### PR DESCRIPTION
## Summary
- add Web/High-Res download buttons for each portrait
- style new buttons in gray

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d3b924870832db40051f2b1b437fc