### PR TITLE
Remove homepage copyright

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,13 +72,11 @@
         <section class="hero">
             <div class="image-overlay">
                 <img src="/graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
-                <p class="photo-credit gray">&copy; Lorenzo Chiacchieroni</p>
             </div>
         </section>
     </main>
     <footer>
         <div class="container">
-            <p>&copy; 2025 Leonardo Matteucci</p>
             <div class="footer-icons">
                 <a href="https://www.youtube.com/@leonardo_matteucci" title="YouTube" target="_blank">
                     <img src="logos/youtube-logo_white.svg" alt="YouTube">

--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -46,17 +46,17 @@
                         <div class="portrait-grid">
                             <figure>
                                 <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
-                                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+                                <figcaption class="photo-credit gray">&copy; Lorenzo Chiacchieroni</figcaption>
                                 <a href="../graphics/placeholder.svg" download>Download</a>
                             </figure>
                             <figure>
                                 <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
-                                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+                                <figcaption class="photo-credit gray">&copy; Lorenzo Chiacchieroni</figcaption>
                                 <a href="../graphics/placeholder.svg" download>Download</a>
                             </figure>
                             <figure>
                                 <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
-                                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+                                <figcaption class="photo-credit gray">&copy; Lorenzo Chiacchieroni</figcaption>
                                 <a href="../graphics/placeholder.svg" download>Download</a>
                             </figure>
                         </div>


### PR DESCRIPTION
## Summary
- remove copyright line and photo credit from home page
- style press kit photo captions with the same credit style

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d3bf90bf4832d913d32948722d65d