### PR TITLE
Add clipboard copy button and subtitles to press kit

### DIFF
--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -37,8 +37,12 @@
                 <li>
                     <details class="press-item" open>
                         <summary class="list-title">Short Biography (Press Version)</summary>
-                        <p class="works-details">Leonardo Matteucci (*2000) is an Italian composer based in Graz, Austria. His works explore the intersection of acoustic gesture and electronic transformation, inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation. His works have been performed by ensembles such as Opificio Sonoro, Quartetto Maurice, and Collettivo_21. He is currently pursuing his Master’s degree in Composition at Kunstuniversität Graz under Franck Bedrossian.</p>
+                        <p id="press-bio-text" class="works-details">Leonardo Matteucci (*2000) is an Italian composer based in Graz, Austria. His works explore the intersection of acoustic gesture and electronic transformation, inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation. His works have been performed by ensembles such as Opificio Sonoro, Quartetto Maurice, and Collettivo_21. He is currently pursuing his Master’s degree in Composition at Kunstuniversität Graz under Franck Bedrossian.</p>
+                        <div class="copy-buttons">
+                            <button id="copy-bio" class="download-button gray" type="button">copy</button>
+                        </div>
                     </details>
+                    <span class="works-details italic press-subtitle">press kit short bio – 700 characters</span>
                 </li>
                 <li>
                     <details class="press-item">
@@ -70,6 +74,7 @@
                             </figure>
                         </div>
                     </details>
+                    <span class="works-details italic press-subtitle">download web (72ppi) and original, high-resolution (300 ppi) portrait pictures</span>
                 </li>
             </ul>
         </section>
@@ -96,6 +101,7 @@
             </div>
         </div>
     </footer>
+    <script src="./press-kit.js"></script>
     <script src="../transition.js"></script>
     <script src="../ruler.js"></script>
 </body>

--- a/press-kit/press-kit.js
+++ b/press-kit/press-kit.js
@@ -1,0 +1,9 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const copyBtn = document.getElementById('copy-bio');
+  const bioText = document.getElementById('press-bio-text');
+  if (copyBtn && bioText) {
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(bioText.textContent.trim());
+    });
+  }
+});

--- a/style.css
+++ b/style.css
@@ -1251,3 +1251,17 @@ body.fade-out {
 .download-button:hover {
     background-color: rgba(255, 255, 255, 0.12);
 }
+
+.copy-buttons {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: var(--spacing-small);
+}
+
+.press-subtitle {
+    display: block;
+}
+
+details.press-item[open] + .press-subtitle {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- add copy-to-clipboard button for short press bio
- hideable subtitles for each dropdown section
- add small script for clipboard support
- update styling for new elements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d42077040832dabb3f5fa7a4b37c8