### PR TITLE
Add photo year overlay

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -39,6 +39,7 @@
             </div>
             <div class="image-overlay">
                 <img src="../graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
+                <p class="photo-credit photo-year gray">2025</p>
                 <p class="photo-credit gray">&copy; Lorenzo Chiacchieroni</p>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
         <section class="hero">
             <div class="image-overlay">
                 <img src="/graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
+                <p class="photo-credit photo-year gray">2025</p>
                 <p class="photo-credit gray">&copy; Lorenzo Chiacchieroni</p>
             </div>
         </section>

--- a/style.css
+++ b/style.css
@@ -573,6 +573,18 @@ img {
     padding: 0.2em 0.4em;
     background: rgba(0, 0, 0, 0.6);
 }
+
+/* Position year of photo at top-left corner with the same style */
+.image-overlay .photo-year {
+    position: absolute;
+    top: 0.3em;
+    left: 0.3em;
+    width: auto;
+    max-width: none;
+    margin: 0;
+    padding: 0.2em 0.4em;
+    background: rgba(0, 0, 0, 0.6);
+}
 .logo img,
 .footer-icons img {
     margin-top: 0;


### PR DESCRIPTION
## Summary
- show "2025" in the corner of hero photos
- reuse photo-credit styling and position on top-left

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d4364394c832da66aa29139532d01