### PR TITLE
Add year credit for press kit photos

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -39,7 +39,6 @@
             </div>
             <div class="image-overlay">
                 <img src="../graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
-                <p class="photo-credit photo-year gray">2025</p>
                 <p class="photo-credit gray">&copy; Lorenzo Chiacchieroni</p>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -72,7 +72,6 @@
         <section class="hero">
             <div class="image-overlay">
                 <img src="/graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
-                <p class="photo-credit photo-year gray">2025</p>
                 <p class="photo-credit gray">&copy; Lorenzo Chiacchieroni</p>
             </div>
         </section>

--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -50,6 +50,7 @@
                         <div class="portrait-grid">
                             <figure>
                                 <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
+                                <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
                                     <a href="../graphics/placeholder.svg" download class="download-button gray">web</a>
@@ -58,6 +59,7 @@
                             </figure>
                             <figure>
                                 <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
+                                <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
                                     <a href="../graphics/placeholder.svg" download class="download-button gray">web</a>
@@ -66,6 +68,7 @@
                             </figure>
                             <figure>
                                 <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
+                                <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
                                     <a href="../graphics/placeholder.svg" download class="download-button gray">web</a>

--- a/style.css
+++ b/style.css
@@ -1241,6 +1241,17 @@ body.fade-out {
     margin-top: 0;
 }
 
+/* Year label for press kit portraits */
+.portrait-grid .photo-year {
+    position: absolute;
+    top: 0.5em;
+    right: 0.5em;
+    background: rgba(0, 0, 0, 0.6);
+    color: #ffffff;
+    padding: 0.2em 0.4em;
+    font-size: 0.9em;
+}
+
 /* Download button styles for press kit portraits */
 .download-buttons {
     display: flex;


### PR DESCRIPTION
## Summary
- remove the year overlay from Home and About photos
- show the year **2025** on each press kit portrait
- style the new year label in the top-right corner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d464c8f1c832d9b1a7bb93100ceb1