### PR TITLE
Remove photo credits

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -39,7 +39,6 @@
             </div>
             <div class="image-overlay">
                 <img src="../graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
-                <p class="photo-credit gray">&copy; Lorenzo Chiacchieroni</p>
             </div>
         </section>
     </main>

--- a/index.html
+++ b/index.html
@@ -72,7 +72,6 @@
         <section class="hero">
             <div class="image-overlay">
                 <img src="/graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
-                <p class="photo-credit gray">&copy; Lorenzo Chiacchieroni</p>
             </div>
         </section>
     </main>

--- a/style.css
+++ b/style.css
@@ -545,15 +545,6 @@ img {
     margin-left: auto;
     margin-right: auto;
 }
-.photo-credit {
-    width: 40%;
-    max-width: 700px;
-    margin: 0.5em auto 0;
-    text-align: right;
-    font-size: 0.8em;
-    color: #bbbbbb;
-}
-
 .image-overlay {
     position: relative;
     display: inline-block;
@@ -561,17 +552,6 @@ img {
 
 .image-overlay img {
     display: block;
-}
-
-.image-overlay .photo-credit {
-    position: absolute;
-    bottom: 0.3em;
-    right: 0.3em;
-    width: auto;
-    max-width: none;
-    margin: 0;
-    padding: 0.2em 0.4em;
-    background: rgba(0, 0, 0, 0.6);
 }
 
 /* Position year of photo at top-left corner with the same style */


### PR DESCRIPTION
## Summary
- strip photo credit overlay from home and about pages
- remove unused `.photo-credit` styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d47e7baa4832d9e244591234215e9