### PR TITLE
Add student email to contact page

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -35,6 +35,7 @@
         <section>
             <h1>Contact</h1>
             <p>Email: <a href="mailto:leonardo.matteucci@icloud.com">leonardo.matteucci@icloud.com</a></p>
+            <p>Student Email: <a href="mailto:leonardo.matteucci@student.kug.ac.at">leonardo.matteucci@student.kug.ac.at</a></p>
             <p>Phone: <span id="phone" data-encoded="KzM5IDAwMCAwMDAgMDAwMA==">Click to reveal</span></p>
         </section>
     </main>


### PR DESCRIPTION
## Summary
- add student university email address to the contact page.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e1e329694832d95b51695525ba1b1