### PR TITLE
Add plus sign to contact phone number prefix

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -46,7 +46,7 @@
                 </li>
                 <li>
                     <span class="list-title">Phone</span>
-                    <span class="works-details">39 393 228 2032 <span class="italic">(messages only)</span></span>
+                    <span class="works-details">+39 393 228 2032 <span class="italic">(messages only)</span></span>
                 </li>
             </ul>
             <p>Thanks for your interest,<br>Leo</p>


### PR DESCRIPTION
## Summary
- include international +39 prefix for the contact phone number to improve dialing clarity

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e23267f04832db852ea1c738d0854