### PR TITLE
Use 'works' instead of 'compositions' across pages

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -34,7 +34,7 @@
     <main>
         <section>
             <h1>Contact</h1>
-            <p>Feel free to reach out to request scores, performance materials, or further details about my compositions and projects.</p>
+            <p>Feel free to reach out to request scores, performance materials, or further details about my works and projects.</p>
             <ul class="works-list">
                 <li>
                     <span class="list-title">Email</span>

--- a/works/index.html
+++ b/works/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Catalogue of compositions by Leonardo Matteucci with instrumentation and year of creation.">
+    <meta name="description" content="Catalogue of works by Leonardo Matteucci with instrumentation and year of creation.">
     <title>Works - Leonardo Matteucci</title>
     <link rel="icon" href="../logos/lm-logo-favicon.svg" type="image/svg+xml">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- Update contact page copy to say "works and projects" rather than "compositions and projects".
- Update works page meta description to describe "Catalogue of works".

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e235fe890832da3613c0ca6860f4d