### PR TITLE
Style email links with light weight

### DIFF
--- a/style.css
+++ b/style.css
@@ -435,6 +435,9 @@ a, .link {
     text-decoration: none;
     cursor: pointer;
 }
+a[href^="mailto:"] {
+    font-weight: 300;
+}
 a:hover, .link:hover {
     text-decoration: underline;
 }


### PR DESCRIPTION
## Summary
- Override global link styling so that email links are rendered in a light font weight

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e23d6a1bc832d9088d908bc918f33