### PR TITLE
Remove default underline on nav links

### DIFF
--- a/style.css
+++ b/style.css
@@ -438,7 +438,7 @@ a, .link {
 a:hover, .link:hover {
     text-decoration: underline;
 }
-header nav a:hover {
+header nav a.link:hover {
     text-decoration: none;
 }
 header nav {


### PR DESCRIPTION
## Summary
- prevent default underline on navigation links so only the animation shows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e24e8d8a4832dabfff05a54d6dcba