### PR TITLE
Rename new work placeholder to White bells

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -44,7 +44,7 @@
         <p class="works-details italic mid-margin">for piano</p>
     </div>
     <div class="about-text">
-        <p class="regular"><span class="italic">[New work]</span> (from <span class="italic">Widmung</span>)</p>
+        <p class="regular">White bells (from <span class="italic">Widmung</span>)</p>
         <p class="works-details italic mid-margin">for piano and electronics</p>
     </div>
     <div class="about-text">


### PR DESCRIPTION
## Summary
- Rename placeholder `[New work]` to "White bells" on the Reach Touch project page and remove italic styling for regular text.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e26333ecc832d8da47e793126c23c