### PR TITLE
fix: ensure header nav spans full width

### DIFF
--- a/style.css
+++ b/style.css
@@ -451,8 +451,8 @@ header nav {
     pointer-events: none;
     position: absolute;
     top: calc(var(--header-height) + 1px);
-    left: 0em;
-    right: 2.5em;
+    left: 0;
+    right: 0;
     margin-left: 0;
     flex-direction: row;
     justify-content: space-evenly;
@@ -466,7 +466,7 @@ header nav::after {
     content: "";
     position: absolute;
     bottom: 0;
-    left: 49.4%;
+    left: 50%;
     transform: translateX(-50%);
     width: 100%;
     height: 52px;


### PR DESCRIPTION
## Summary
- expand header nav to fill full page width
- correctly center header nav underline element

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e2780550c832da322a4f257957a20