### PR TITLE
Keep desktop menu open by default

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -2,11 +2,17 @@ window.addEventListener('DOMContentLoaded', () => {
   const menuToggle = document.getElementById('menu-toggle');
   if (!menuToggle) return;
 
-  document.addEventListener('click', (e) => {
-    if (!menuToggle.checked) return;
-    const header = document.querySelector('header');
-    if (!header.contains(e.target)) {
-      menuToggle.checked = false;
-    }
-  });
+  const isDesktop = window.matchMedia('(min-width: 601px)').matches;
+
+  if (isDesktop) {
+    menuToggle.checked = true;
+  } else {
+    document.addEventListener('click', (e) => {
+      if (!menuToggle.checked) return;
+      const header = document.querySelector('header');
+      if (!header.contains(e.target)) {
+        menuToggle.checked = false;
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- Automatically open the hamburger menu on desktop screens
- Prevent menu from closing on outside clicks on desktop
- Preserve existing mobile behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e295982f0832d8802d7fc8ff10c98