### PR TITLE
Remove hover animation from contact list

### DIFF
--- a/style.css
+++ b/style.css
@@ -735,6 +735,16 @@ body.about .about-lines {
     margin-bottom: 0;
 }
 
+/* Disable hover animation on the contact page */
+.contact .works-list li {
+    transition: none;
+}
+
+.contact .works-list li:hover:has(a) {
+    transform: none;
+    background-color: transparent;
+}
+
 /* Press kit list styled like works list */
 .press-list {
     list-style-type: none;


### PR DESCRIPTION
## Summary
- Disable hover animation for contact list items on the contact page by overriding transform, background, and transition styles.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689064a26c14832d887bbf7af798152c