### PR TITLE
Add WhatsApp and Telegram contact links

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -45,8 +45,12 @@
                     <span class="works-details"><a href="mailto:leonardo.matteucci@student.kug.ac.at" class="link">leonardo.matteucci@student.kug.ac.at</a></span>
                 </li>
                 <li>
-                    <span class="list-title">Phone</span>
-                    <span class="works-details">+39 393 228 2032 <span class="italic">(messages only)</span></span>
+                    <span class="list-title">WhatsApp</span>
+                    <span class="works-details"><a href="https://wa.me/393932282032" class="link">wa.me/393932282032</a></span>
+                </li>
+                <li>
+                    <span class="list-title">Telegram</span>
+                    <span class="works-details"><a href="https://t.me/leonardo_matteucci" class="link">t.me/leonardo_matteucci</a></span>
                 </li>
                 <li>
                     <span class="list-title">YouTube</span>


### PR DESCRIPTION
## Summary
- replace phone contact with WhatsApp link
- add Telegram username link for messaging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890666a393c832da57d809eb0ce3c40