### PR TITLE
Add black-and-white portraits to press kit

### DIFF
--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -50,30 +50,75 @@
                         <summary class="list-title">Portraits</summary>
                         <div class="portrait-grid">
                             <figure>
-                                <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
+                                <img src="../graphics/photo-LC-1-bw.jpg" alt="Portrait 1">
                                 <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
-                                    <a href="../graphics/placeholder.svg" download class="download-button gray">web</a>
-                                    <a href="../graphics/placeholder.svg" download class="download-button gray">high-res</a>
+                                    <a href="../graphics/photo-LC-1-bw.jpg" download class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-1-bw.jpg" download class="download-button gray">high-res</a>
                                 </div>
                             </figure>
                             <figure>
-                                <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
+                                <img src="../graphics/photo-LC-2-bw.jpg" alt="Portrait 2">
                                 <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
-                                    <a href="../graphics/placeholder.svg" download class="download-button gray">web</a>
-                                    <a href="../graphics/placeholder.svg" download class="download-button gray">high-res</a>
+                                    <a href="../graphics/photo-LC-2-bw.jpg" download class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-2-bw.jpg" download class="download-button gray">high-res</a>
                                 </div>
                             </figure>
                             <figure>
-                                <img src="../graphics/placeholder.svg" alt="Portrait placeholder">
+                                <img src="../graphics/photo-LC-3-bw.jpg" alt="Portrait 3">
                                 <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
-                                    <a href="../graphics/placeholder.svg" download class="download-button gray">web</a>
-                                    <a href="../graphics/placeholder.svg" download class="download-button gray">high-res</a>
+                                    <a href="../graphics/photo-LC-3-bw.jpg" download class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-3-bw.jpg" download class="download-button gray">high-res</a>
+                                </div>
+                            </figure>
+                            <figure>
+                                <img src="../graphics/photo-LC-4-bw.jpg" alt="Portrait 4">
+                                <span class="photo-year">2025</span>
+                                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+                                <div class="download-buttons">
+                                    <a href="../graphics/photo-LC-4-bw.jpg" download class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-4-bw.jpg" download class="download-button gray">high-res</a>
+                                </div>
+                            </figure>
+                            <figure>
+                                <img src="../graphics/photo-LC-5-bw.jpg" alt="Portrait 5">
+                                <span class="photo-year">2025</span>
+                                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+                                <div class="download-buttons">
+                                    <a href="../graphics/photo-LC-5-bw.jpg" download class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-5-bw.jpg" download class="download-button gray">high-res</a>
+                                </div>
+                            </figure>
+                            <figure>
+                                <img src="../graphics/photo-LC-7-bw.jpg" alt="Portrait 7">
+                                <span class="photo-year">2025</span>
+                                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+                                <div class="download-buttons">
+                                    <a href="../graphics/photo-LC-7-bw.jpg" download class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-7-bw.jpg" download class="download-button gray">high-res</a>
+                                </div>
+                            </figure>
+                            <figure>
+                                <img src="../graphics/photo-LC-8-bw.jpg" alt="Portrait 8">
+                                <span class="photo-year">2025</span>
+                                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+                                <div class="download-buttons">
+                                    <a href="../graphics/photo-LC-8-bw.jpg" download class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-8-bw.jpg" download class="download-button gray">high-res</a>
+                                </div>
+                            </figure>
+                            <figure>
+                                <img src="../graphics/photo-LC-pro_pic-bw.jpg" alt="Portrait profile">
+                                <span class="photo-year">2025</span>
+                                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+                                <div class="download-buttons">
+                                    <a href="../graphics/photo-LC-pro_pic-bw.jpg" download class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-pro_pic-bw.jpg" download class="download-button gray">high-res</a>
                                 </div>
                             </figure>
                         </div>


### PR DESCRIPTION
## Summary
- display available black-and-white portrait photos on the press kit page
- provide download buttons for each portrait

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689394b93714832daca547cb861b52de