### PR TITLE
Expand landscape portraits and add missing photo

### DIFF
--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -85,13 +85,22 @@
                                     <a href="../graphics/photo-LC-4-bw.jpg" download class="download-button gray">high-res</a>
                                 </div>
                             </figure>
-                            <figure>
+                            <figure class="landscape">
                                 <img src="../graphics/photo-LC-5-bw.jpg" alt="Portrait 5">
                                 <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
                                     <a href="../graphics/photo-LC-5-bw.jpg" download class="download-button gray">web</a>
                                     <a href="../graphics/photo-LC-5-bw.jpg" download class="download-button gray">high-res</a>
+                                </div>
+                            </figure>
+                            <figure>
+                                <img src="../graphics/photo-LC-6-bw.jpeg" alt="Portrait 6">
+                                <span class="photo-year">2025</span>
+                                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+                                <div class="download-buttons">
+                                    <a href="../graphics/photo-LC-6-bw.jpeg" download class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-6-bw.jpeg" download class="download-button gray">high-res</a>
                                 </div>
                             </figure>
                             <figure>
@@ -112,7 +121,7 @@
                                     <a href="../graphics/photo-LC-8-bw.jpg" download class="download-button gray">high-res</a>
                                 </div>
                             </figure>
-                            <figure>
+                            <figure class="landscape">
                                 <img src="../graphics/photo-LC-pro_pic-bw.jpg" alt="Portrait profile">
                                 <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>

--- a/style.css
+++ b/style.css
@@ -1221,6 +1221,10 @@ body.fade-out {
     position: relative;
 }
 
+.portrait-grid figure.landscape {
+    grid-column: span 2;
+}
+
 .portrait-grid figcaption,
 .portrait-grid a {
     font-size: 0.9em;


### PR DESCRIPTION
## Summary
- make landscape portrait images span two columns in the press kit grid
- add photo-LC-6-bw and flag landscape photos accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893a198fb0c832da35240e9e6f1c4e8