### PR TITLE
Refine press kit dropdowns and labels

### DIFF
--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -36,8 +36,8 @@
             <h1>Press Kit</h1>
             <ul class="works-list press-list">
                 <li>
-                    <details class="press-item" open>
-                        <summary class="list-title">Short Biography (Press Version)</summary>
+                    <details class="press-item">
+                        <summary class="list-title">Biography (Press Version)</summary>
                         <p id="press-bio-text" class="works-details">Leonardo Matteucci (*2000) is an Italian composer based in Graz, Austria. His works explore the intersection of acoustic gesture and electronic transformation, inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation. His works have been performed by ensembles such as Opificio Sonoro, Quartetto Maurice, and Collettivo_21. He is currently pursuing his Master’s degree in Composition at Kunstuniversität Graz under Franck Bedrossian.</p>
                         <div class="copy-buttons">
                             <button id="copy-bio" class="download-button gray" type="button">copy</button>
@@ -47,7 +47,7 @@
                 </li>
                 <li>
                     <details class="press-item">
-                        <summary class="list-title">Portraits</summary>
+                        <summary class="list-title">Photos</summary>
                         <div class="portrait-grid">
                             <figure>
                                 <img src="../graphics/photo-LC-1-bw.jpg" alt="Portrait 1">

--- a/style.css
+++ b/style.css
@@ -761,26 +761,33 @@ body.about .about-lines {
     margin-bottom: 1.5em;
     padding-left: 1em;
     border-left: 3px solid #555555;
-    transition: transform 0.3s ease, background-color 0.3s ease;
 }
 
 .press-list li:last-child {
     margin-bottom: 0;
 }
 
-.press-list li:hover {
-    transform: translateX(5px);
-    background-color: rgba(255, 255, 255, 0.12);
-}
-
 .press-item > summary {
     list-style: none;
     cursor: pointer;
     font-weight: 300;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .press-item > summary::-webkit-details-marker {
     display: none;
+}
+
+.press-item > summary::after {
+    content: '▼';
+    font-size: 0.8em;
+    transition: transform 0.3s ease;
+}
+
+details.press-item[open] > summary::after {
+    transform: rotate(-180deg);
 }
 
 /* Titles for entries in the Works and Projects index pages */


### PR DESCRIPTION
## Summary
- rename press kit sections and collapse by default
- remove hover animation and add arrow toggle icons for dropdowns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893a3367b30832d996a2a36db8211dd