### PR TITLE
Style press kit disclosure arrows

### DIFF
--- a/style.css
+++ b/style.css
@@ -783,11 +783,24 @@ body.about .about-lines {
 .press-item > summary::after {
     content: '▼';
     font-size: 0.8em;
-    transition: transform 0.3s ease;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 1.6em;
+    height: 1.6em;
+    margin-left: 0.5em;
+    border-radius: 50%;
+    background-color: rgba(255, 255, 255, 0.12);
+    transition: transform 0.3s ease, background-color 0.3s ease;
+}
+
+.press-item > summary:hover::after {
+    background-color: rgba(255, 255, 255, 0.2);
 }
 
 details.press-item[open] > summary::after {
     transform: rotate(-180deg);
+    background-color: rgba(255, 255, 255, 0.2);
 }
 
 /* Titles for entries in the Works and Projects index pages */


### PR DESCRIPTION
## Summary
- Enclose press kit disclosure arrows in a gray circular button for visual consistency

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893a532804c832d94b0b7a751c10ea6