### PR TITLE
fix: disable press-kit hover animation

### DIFF
--- a/style.css
+++ b/style.css
@@ -735,12 +735,14 @@ body.about .about-lines {
     margin-bottom: 0;
 }
 
-/* Disable hover animation on the contact page */
-.contact .works-list li {
+/* Disable hover animation on the contact and press kit pages */
+.contact .works-list li,
+.press-kit .works-list li {
     transition: none;
 }
 
-.contact .works-list li:hover:has(a) {
+.contact .works-list li:hover:has(a),
+.press-kit .works-list li:hover:has(a) {
     transform: none;
     background-color: transparent;
 }


### PR DESCRIPTION
## Summary
- stop works list items from shifting on press-kit page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893a4fc0ed8832d9d530e0902054639