### PR TITLE
Ensure press-kit photos open in new tab

### DIFF
--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -54,8 +54,8 @@
                                 <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
-                                    <a href="../graphics/photo-LC-1-bw.jpg" download class="download-button gray">web</a>
-                                    <a href="../graphics/photo-LC-1-bw.jpg" download class="download-button gray">high-res</a>
+                                    <a href="../graphics/photo-LC-1-bw.jpg" target="_blank" class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-1-bw.jpg" target="_blank" class="download-button gray">high-res</a>
                                 </div>
                             </figure>
                             <figure>
@@ -63,8 +63,8 @@
                                 <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
-                                    <a href="../graphics/photo-LC-3-bw.jpg" download class="download-button gray">web</a>
-                                    <a href="../graphics/photo-LC-3-bw.jpg" download class="download-button gray">high-res</a>
+                                    <a href="../graphics/photo-LC-3-bw.jpg" target="_blank" class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-3-bw.jpg" target="_blank" class="download-button gray">high-res</a>
                                 </div>
                             </figure>
                             <figure>
@@ -72,8 +72,8 @@
                                 <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
-                                    <a href="../graphics/photo-LC-4-bw.jpg" download class="download-button gray">web</a>
-                                    <a href="../graphics/photo-LC-4-bw.jpg" download class="download-button gray">high-res</a>
+                                    <a href="../graphics/photo-LC-4-bw.jpg" target="_blank" class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-4-bw.jpg" target="_blank" class="download-button gray">high-res</a>
                                 </div>
                             </figure>
                             <figure class="landscape">
@@ -81,8 +81,8 @@
                                 <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
-                                    <a href="../graphics/photo-LC-5-bw.jpg" download class="download-button gray">web</a>
-                                    <a href="../graphics/photo-LC-5-bw.jpg" download class="download-button gray">high-res</a>
+                                    <a href="../graphics/photo-LC-5-bw.jpg" target="_blank" class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-5-bw.jpg" target="_blank" class="download-button gray">high-res</a>
                                 </div>
                             </figure>
                             <figure>
@@ -90,8 +90,8 @@
                                 <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
-                                    <a href="../graphics/photo-LC-8-bw.jpg" download class="download-button gray">web</a>
-                                    <a href="../graphics/photo-LC-8-bw.jpg" download class="download-button gray">high-res</a>
+                                    <a href="../graphics/photo-LC-8-bw.jpg" target="_blank" class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-8-bw.jpg" target="_blank" class="download-button gray">high-res</a>
                                 </div>
                             </figure>
                             <figure class="landscape">
@@ -99,8 +99,8 @@
                                 <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
-                                    <a href="../graphics/photo-LC-pro_pic-bw.jpg" download class="download-button gray">web</a>
-                                    <a href="../graphics/photo-LC-pro_pic-bw.jpg" download class="download-button gray">high-res</a>
+                                    <a href="../graphics/photo-LC-pro_pic-bw.jpg" target="_blank" class="download-button gray">web</a>
+                                    <a href="../graphics/photo-LC-pro_pic-bw.jpg" target="_blank" class="download-button gray">high-res</a>
                                 </div>
                             </figure>
                         </div>


### PR DESCRIPTION
## Summary
- Open press-kit photos in a new tab instead of downloading

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893aa72c1a4832d9b76b3518d71ac40