### PR TITLE
Ensure press kit photos display singly on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1278,6 +1278,16 @@ body.fade-out {
     font-size: 0.9em;
 }
 
+@media (max-width: 600px) {
+    .portrait-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .portrait-grid figure.landscape {
+        grid-column: span 1;
+    }
+}
+
 /* Download button styles for press kit portraits */
 .download-buttons {
     display: flex;


### PR DESCRIPTION
## Summary
- Force press kit photo grid into a single column at widths below 600px.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893ab4bbed0832db830f3319cc4e20c