### PR TITLE
Remove copy button from press kit

### DIFF
--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -39,9 +39,6 @@
                     <details class="press-item">
                         <summary class="list-title">Biography (Press Version)</summary>
                         <p id="press-bio-text" class="works-details">Leonardo Matteucci (*2000) is an Italian composer based in Graz, Austria. His works explore the intersection of acoustic gesture and electronic transformation, inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation. His works have been performed by ensembles such as Opificio Sonoro, Quartetto Maurice, and Collettivo_21. He is currently pursuing his Master’s degree in Composition at Kunstuniversität Graz under Franck Bedrossian.</p>
-                        <div class="copy-buttons">
-                            <button id="copy-bio" class="download-button gray" type="button">copy</button>
-                        </div>
                     </details>
                     <span class="works-details italic press-subtitle">press kit short bio – 700 characters</span>
                 </li>
@@ -132,7 +129,6 @@
             </div>
         </div>
     </footer>
-    <script src="./press-kit.js"></script>
     <script src="../transition.js"></script>
     <script src="../ruler.js"></script>
     <script src="../menu.js"></script>

--- a/press-kit/press-kit.js
+++ b/press-kit/press-kit.js
@@ -1,9 +1,0 @@
-window.addEventListener('DOMContentLoaded', () => {
-  const copyBtn = document.getElementById('copy-bio');
-  const bioText = document.getElementById('press-bio-text');
-  if (copyBtn && bioText) {
-    copyBtn.addEventListener('click', () => {
-      navigator.clipboard.writeText(bioText.textContent.trim());
-    });
-  }
-});

--- a/style.css
+++ b/style.css
@@ -1311,12 +1311,6 @@ body.fade-out {
     background-color: rgba(255, 255, 255, 0.12);
 }
 
-.copy-buttons {
-    display: flex;
-    justify-content: flex-end;
-    margin-top: var(--spacing-small);
-}
-
 .press-subtitle {
     display: block;
 }


### PR DESCRIPTION
## Summary
- remove biography copy button from press kit
- drop unused script and related styling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893ac5daba4832dae4df5eb83a7b2a3