### PR TITLE
Make press kit headings regular weight

### DIFF
--- a/style.css
+++ b/style.css
@@ -772,7 +772,7 @@ body.about .about-lines {
 .press-item > summary {
     list-style: none;
     cursor: pointer;
-    font-weight: 300;
+    font-weight: 400;
     display: flex;
     justify-content: space-between;
     align-items: center;


### PR DESCRIPTION
## Summary
- Use regular (400) font weight for press kit item summaries to match Works section styling.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893af4cac94832d84b915dd70029c83