### PR TITLE
Remove 2025 labels from press kit photos

### DIFF
--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -44,11 +44,10 @@
                 </li>
                 <li>
                     <details class="press-item">
-                        <summary class="list-title">Photos (2025)</summary>
+                        <summary class="list-title">Photos</summary>
                         <div class="portrait-grid">
                             <figure>
                                 <img src="../graphics/photo-LC-1-bw.jpg" alt="Portrait 1">
-                                <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
                                     <a href="../graphics/photo-LC-1-bw.jpg" target="_blank" class="download-button gray">web</a>
@@ -57,7 +56,6 @@
                             </figure>
                             <figure>
                                 <img src="../graphics/photo-LC-4-bw.jpg" alt="Portrait 4">
-                                <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
                                     <a href="../graphics/photo-LC-4-bw.jpg" target="_blank" class="download-button gray">web</a>
@@ -66,7 +64,6 @@
                             </figure>
                             <figure class="landscape">
                                 <img src="../graphics/photo-LC-5-bw.jpg" alt="Portrait 5">
-                                <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
                                     <a href="../graphics/photo-LC-5-bw.jpg" target="_blank" class="download-button gray">web</a>
@@ -75,7 +72,6 @@
                             </figure>
                             <figure>
                                 <img src="../graphics/photo-LC-3-bw.jpg" alt="Portrait 3">
-                                <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
                                     <a href="../graphics/photo-LC-3-bw.jpg" target="_blank" class="download-button gray">web</a>
@@ -84,7 +80,6 @@
                             </figure>
                             <figure>
                                 <img src="../graphics/photo-LC-8-bw.jpg" alt="Portrait 8">
-                                <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
                                     <a href="../graphics/photo-LC-8-bw.jpg" target="_blank" class="download-button gray">web</a>
@@ -93,7 +88,6 @@
                             </figure>
                             <figure class="landscape">
                                 <img src="../graphics/photo-LC-pro_pic-bw.jpg" alt="Portrait profile">
-                                <span class="photo-year">2025</span>
                                 <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
                                 <div class="download-buttons">
                                     <a href="../graphics/photo-LC-pro_pic-bw.jpg" target="_blank" class="download-button gray">web</a>

--- a/style.css
+++ b/style.css
@@ -557,17 +557,6 @@ img {
     display: block;
 }
 
-/* Position year of photo at top-left corner with the same style */
-.image-overlay .photo-year {
-    position: absolute;
-    top: 0.3em;
-    left: 0.3em;
-    width: auto;
-    max-width: none;
-    margin: 0;
-    padding: 0.2em 0.4em;
-    background: rgba(0, 0, 0, 0.6);
-}
 .logo img,
 .footer-icons img {
     margin-top: 0;
@@ -1267,16 +1256,6 @@ body.fade-out {
     margin-top: 0;
 }
 
-/* Year label for press kit portraits */
-.portrait-grid .photo-year {
-    position: absolute;
-    top: 0.5em;
-    right: 0.5em;
-    background: rgba(0, 0, 0, 0.6);
-    color: #ffffff;
-    padding: 0.2em 0.4em;
-    font-size: 0.9em;
-}
 
 @media (max-width: 600px) {
     .portrait-grid {


### PR DESCRIPTION
## Summary
- Remove 2025 year tags from press kit photos
- Drop unused `.photo-year` styles from site stylesheet

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893af84c9d0832d92fe84d70eb2b660