### PR TITLE
Rename press-kit biography heading to 2025

### DIFF
--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -37,7 +37,7 @@
             <ul class="works-list press-list">
                 <li>
                     <details class="press-item">
-                        <summary class="list-title">Biography (Press Version)</summary>
+                        <summary class="list-title">Biography (2025)</summary>
                         <p id="press-bio-text" class="works-details">Leonardo Matteucci (*2000) is an Italian composer based in Graz, Austria. His works explore the intersection of acoustic gesture and electronic transformation, inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation. His works have been performed by ensembles such as Opificio Sonoro, Quartetto Maurice, and Collettivo_21. He is currently pursuing his Master’s degree in Composition at Kunstuniversität Graz under Franck Bedrossian.</p>
                     </details>
                     <span class="works-details italic press-subtitle">press kit short bio – 700 characters</span>


### PR DESCRIPTION
## Summary
- Update press kit to label the biography section as "Biography (2025)"

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893b0249e0c832dbcc3d3e8211caa4e