### PR TITLE
Add LC-7-bw portrait to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,12 @@
                 <img src="/graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
             </div>
         </section>
+        <section class="feature-portrait">
+            <figure>
+                <img src="/graphics/photo-LC-7-bw.jpg" alt="Leonardo Matteucci portrait">
+                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+            </figure>
+        </section>
     </main>
     <footer>
         <div class="container">

--- a/style.css
+++ b/style.css
@@ -1045,6 +1045,22 @@ hr[class*="separator"] + h3 {
     animation: heroImage 0.6s ease forwards;
 }
 
+.feature-portrait {
+    text-align: center;
+    margin-top: var(--spacing-large);
+}
+
+.feature-portrait img {
+    width: 85%;
+    max-width: 500px;
+    height: auto;
+}
+
+.feature-portrait figcaption {
+    margin-top: 0.5em;
+    font-size: 0.9em;
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- Display LC-7-bw portrait on the homepage with a centered figure and caption.
- Style the new portrait section for responsive, professional sizing.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68966753e688832daf28c362b6e98b88