### PR TITLE
Add LC-7-bw portrait to About page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -42,6 +42,12 @@
                 <img src="../graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
             </div>
         </section>
+        <section class="feature-portrait">
+            <figure>
+                <img src="../graphics/photo-LC-7-bw.jpg" alt="Leonardo Matteucci portrait">
+                <figcaption>&copy; Lorenzo Chiacchieroni</figcaption>
+            </figure>
+        </section>
     </main>
     <footer>
         <div class="container">


### PR DESCRIPTION
## Summary
- Display the LC-7-bw portrait with credit on the About page.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68966944885c832da78d8507c2a07852