### PR TITLE
Redesign site with new dark palette and hero

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -6,7 +6,6 @@
     <meta name="description" content="Biography and artistic focus of composer Leonardo Matteucci, exploring corporeality and acoustic-electronic hybridisation.">
     <title>About - Leonardo Matteucci</title>
     <link rel="icon" href="../logos/lm-logo-favicon.svg" type="image/svg+xml">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body class="about">

--- a/contact/index.html
+++ b/contact/index.html
@@ -6,7 +6,6 @@
     <meta name="description" content="Get in touch with Leonardo Matteucci via email or phone.">
     <title>Contact - Leonardo Matteucci</title>
     <link rel="icon" href="../logos/lm-logo-favicon.svg" type="image/svg+xml">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body class="contact">

--- a/events/index.html
+++ b/events/index.html
@@ -6,7 +6,6 @@
     <meta name="description" content="Schedule of upcoming and past performances of Leonardo Matteucci's works with venues and performers.">
     <title>Events - Leonardo Matteucci</title>
     <link rel="icon" href="../logos/lm-logo-favicon.svg" type="image/svg+xml">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
     <title>Home - Leonardo Matteucci</title>
     <meta name="description" content="Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation. He studied in Turin with Giorgio Colombo Taccani from 2019 to 2021, and in Fermo with Marco Momi from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the Kunstuniversität Graz.">
     <link rel="icon" href="logos/lm-logo-favicon.svg" type="image/svg+xml">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Leonardo Matteucci">
     <meta property="og:description" content="Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation. He studied in Turin with Giorgio Colombo Taccani from 2019 to 2021, and in Fermo with Marco Momi from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the Kunstuniversität Graz.">
@@ -69,12 +68,16 @@
         </div>
     </header>
 
-    <main>
-        <section class="hero">
-            <div class="image-overlay">
-                <img src="/graphics/DSC07515.jpg" alt="Leonardo Matteucci" class="placeholder-image">
-            </div>
-        </section>
+    <!-- Hero banner -->
+    <section class="hero">
+      <div class="hero-content">
+        <h1>Leonardo Matteucci</h1>
+        <p>Composer exploring inner corporeality, body mechanics and acoustic‑electronic hybridisation.</p>
+        <button class="cta-button" onclick="location.href='/works/'">Listen to my works</button>
+      </div>
+    </section>
+
+    <main class="container">
         <section class="feature-portrait">
             <figure>
                 <img src="/graphics/photo-LC-7-bw.jpg" alt="Leonardo Matteucci portrait">

--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -6,7 +6,6 @@
     <meta name="description" content="Press materials for composer Leonardo Matteucci, including a short biography and portrait photos.">
     <title>Press Kit - Leonardo Matteucci</title>
     <link rel="icon" href="../logos/lm-logo-favicon.svg" type="image/svg+xml">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body class="press-kit">

--- a/projects/index.html
+++ b/projects/index.html
@@ -6,7 +6,6 @@
     <meta name="description" content="Overview of Leonardo Matteucci's collaborative projects, including the Reach.Touch. series.">
     <title>Projects - Leonardo Matteucci</title>
     <link rel="icon" href="../logos/lm-logo-favicon.svg" type="image/svg+xml">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>

--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Reach.Touch. - Leonardo Matteucci</title>
     <link rel="icon" href="../../logos/lm-logo-favicon.svg" type="image/svg+xml">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../style.css">
 </head>
 <body>

--- a/style.css
+++ b/style.css
@@ -1,9 +1,15 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Source+Sans+Pro:wght@300;400;600&display=swap');
+
 :root {
+    --bg-color: #0f0f0f;
+    --text-color: #ffffff;
+    --body-color: #d4d4d4;
+    --accent-color: #c49a6c;
     --header-height: 100px;
     --footer-height: 100px;
     --separator-width: 50%;
-    --spacing-large: 0.75em;
-    --spacing-small: 0.5em;
+    --spacing-large: 1.2em;
+    --spacing-small: 0.6em;
 }
 
 html {
@@ -12,16 +18,22 @@ html {
 
 body {
     margin: 0;
-    font-family: 'Roboto', sans-serif;
+    background-color: var(--bg-color);
+    color: var(--body-color);
+    font-family: 'Source Sans Pro', sans-serif;
     font-weight: 300;
-    background-color: #000000;
-    color: #ffffff;
-    line-height: 1.6;
-    border-top: 1px solid #555555;
+    line-height: 1.7;
+    border-top: 1px solid #444444;
+}
+
+h1, h2, h3 {
+    font-family: 'Playfair Display', serif;
+    color: var(--text-color);
+    margin: 0 0 var(--spacing-small);
 }
 
 .container {
-    max-width: 700px;
+    max-width: 900px;
     margin-left: auto;
     margin-right: auto;
     padding: 0 2vw;
@@ -31,7 +43,7 @@ header {
     top: 0;
     left: 0;
     right: 0;
-    background-color: #000000;
+    background-color: var(--bg-color);
     border-bottom: none;
     z-index: 1000;
 }
@@ -43,7 +55,7 @@ header::after {
     left: 50%;
     transform: translateX(-50%);
     width: 100%;
-    border-bottom: 1px solid #555555;
+    border-bottom: 1px solid #444444;
 }
 
 header .container {
@@ -1285,4 +1297,130 @@ body.fade-out {
 
 details.press-item[open] + .press-subtitle {
     display: none;
+}
+
+/* --- New design tweaks --- */
+header nav {
+    display: flex;
+    gap: 2em;
+    visibility: visible;
+    opacity: 1;
+    pointer-events: auto;
+    position: static;
+    transform: none;
+    background: none;
+}
+
+header nav::after {
+    display: none;
+}
+
+header nav a {
+    color: var(--text-color);
+    text-transform: uppercase;
+    font-weight: 400;
+    letter-spacing: 0.05em;
+    text-decoration: none;
+    transition: color 0.3s ease;
+    opacity: 1;
+    padding: var(--spacing-small) 0;
+}
+
+header nav a:hover,
+header nav a:focus {
+    color: var(--accent-color);
+}
+
+header nav a.active {
+    color: var(--accent-color);
+}
+
+.menu-icon {
+    display: none;
+}
+
+.menu-toggle {
+    display: none;
+}
+
+@media (max-width: 600px) {
+    .menu-icon {
+        display: block;
+    }
+    .menu-toggle {
+        display: block;
+    }
+    header nav {
+        display: none;
+        flex-direction: column;
+        gap: 1em;
+        background-color: var(--bg-color);
+    }
+    #menu-toggle:checked + .menu-icon + nav {
+        display: flex;
+    }
+}
+
+.hero {
+    position: relative;
+    height: 70vh;
+    background-image: url('/graphics/photo-LC-7-bw.jpg');
+    background-size: cover;
+    background-position: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+
+.hero::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.hero-content {
+    position: relative;
+    z-index: 1;
+    max-width: 800px;
+    padding: 0 2vw;
+}
+
+.hero-content h1 {
+    font-size: 3rem;
+    font-weight: 600;
+    margin-bottom: 0.5em;
+}
+
+.hero-content p {
+    font-size: 1.25rem;
+    margin-bottom: var(--spacing-large);
+    color: var(--body-color);
+}
+
+.cta-button {
+    background: var(--accent-color);
+    color: var(--bg-color);
+    border: none;
+    padding: 0.75em 1.5em;
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    cursor: pointer;
+    transition: background 0.3s ease;
+}
+
+.cta-button:hover {
+    background: #a68054;
+}
+
+.footer-icons img {
+    filter: grayscale(100%);
+    transition: transform 0.3s ease, filter 0.3s ease;
+}
+
+.footer-icons a:hover img {
+    transform: translateY(-2px);
+    filter: none;
 }

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>A uno spirituale in Firenze - Leonardo Matteucci</title>
     <link rel="icon" href="../../logos/lm-logo-favicon.svg" type="image/svg+xml">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../style.css">
 </head>
 <body>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Assume - Leonardo Matteucci</title>
     <link rel="icon" href="../../logos/lm-logo-favicon.svg" type="image/svg+xml">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../style.css">
 </head>
 <body>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bodylines - Leonardo Matteucci</title>
     <link rel="icon" href="../../logos/lm-logo-favicon.svg" type="image/svg+xml">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../style.css">
 </head>
 <body>

--- a/works/index.html
+++ b/works/index.html
@@ -6,7 +6,6 @@
     <meta name="description" content="Catalogue of works by Leonardo Matteucci with instrumentation and year of creation.">
     <title>Works - Leonardo Matteucci</title>
     <link rel="icon" href="../logos/lm-logo-favicon.svg" type="image/svg+xml">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../style.css">
 </head>
 <body>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Internal - Leonardo Matteucci</title>
     <link rel="icon" href="../../logos/lm-logo-favicon.svg" type="image/svg+xml">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../style.css">
 </head>
 <body>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Occlusion - Leonardo Matteucci</title>
     <link rel="icon" href="../../logos/lm-logo-favicon.svg" type="image/svg+xml">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Introduce two-tone dark theme and warm accent via CSS variables and font imports
- Add hero banner with call-to-action on home page
- Consolidate font loading and refine navigation styles

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68971f578f0c832da223b2ee8664a5d1