### PR TITLE
Use Roboto and grayscale palette

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,10 +1,10 @@
-@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Source+Sans+Pro:wght@300;400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap');
 
 :root {
     --bg-color: #0f0f0f;
     --text-color: #ffffff;
     --body-color: #d4d4d4;
-    --accent-color: #c49a6c;
+    --accent-color: #888888;
     --header-height: 100px;
     --footer-height: 100px;
     --separator-width: 50%;
@@ -20,14 +20,14 @@ body {
     margin: 0;
     background-color: var(--bg-color);
     color: var(--body-color);
-    font-family: 'Source Sans Pro', sans-serif;
+    font-family: 'Roboto', sans-serif;
     font-weight: 300;
     line-height: 1.7;
     border-top: 1px solid #444444;
 }
 
 h1, h2, h3 {
-    font-family: 'Playfair Display', serif;
+    font-family: 'Roboto', sans-serif;
     color: var(--text-color);
     margin: 0 0 var(--spacing-small);
 }
@@ -211,8 +211,8 @@ body {
     margin: 0;
     font-family: 'Roboto', sans-serif;
     font-weight: 300;
-    background-color: #000000;
-    color: #ffffff;
+    background-color: var(--bg-color);
+    color: var(--text-color);
     line-height: 1.6;
     border-top: 1px solid #555555;
 }
@@ -1328,11 +1328,11 @@ header nav a {
 
 header nav a:hover,
 header nav a:focus {
-    color: var(--accent-color);
+    color: var(--text-color);
 }
 
 header nav a.active {
-    color: var(--accent-color);
+    color: var(--text-color);
 }
 
 .menu-icon {
@@ -1401,7 +1401,7 @@ header nav a.active {
 
 .cta-button {
     background: var(--accent-color);
-    color: var(--bg-color);
+    color: var(--text-color);
     border: none;
     padding: 0.75em 1.5em;
     font-size: 0.9rem;
@@ -1412,7 +1412,7 @@ header nav a.active {
 }
 
 .cta-button:hover {
-    background: #a68054;
+    background: #666666;
 }
 
 .footer-icons img {


### PR DESCRIPTION
## Summary
- Switch site typography to Roboto and unify text colors to black, white, and gray
- Replace accent color with gray and adjust navigation hover/active states
- Update call-to-action button to match grayscale theme

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689721d8c31c832d9c622e9edc6001f7