### PR TITLE
Fix italic styling for press kit subtitles

### DIFF
--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -97,7 +97,7 @@
                             </figure>
                         </div>
                     </details>
-                    <span class="works-details press-subtitle">portraits by Lorenzo Chiacchieroni</span>
+                    <span class="works-details italic press-subtitle">portraits by Lorenzo Chiacchieroni</span>
                 </li>
             </ul>
         </section>

--- a/style.css
+++ b/style.css
@@ -1281,6 +1281,7 @@ body.fade-out {
 
 .press-subtitle {
     display: block;
+    font-style: italic;
 }
 
 details.press-item[open] + .press-subtitle {


### PR DESCRIPTION
## Summary
- Ensure `.press-subtitle` elements render in italics
- Mark second Press Kit subtitle with the `italic` class

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba728327c832d856c82294a629050