### PR TITLE
Use light font for subtitles on Works, Projects, and Press Kit pages

### DIFF
--- a/style.css
+++ b/style.css
@@ -841,6 +841,7 @@ main > section:first-of-type > .works-title:first-child {
 }
 .works-details.italic {
     font-style: italic;
+    font-weight: 300;
 }
 .works-details a {
     color: #bbbbbb;


### PR DESCRIPTION
## Summary
- Ensure subtitle elements consistently render with light font weight for pages that use `works-details` in italic.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bad8e7554832db9adf3aa09fd7a6d