### PR TITLE
feat: add light/dark theme toggle

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -1,11 +1,49 @@
 window.addEventListener('DOMContentLoaded', () => {
   const menuToggle = document.getElementById('menu-toggle');
-  if (!menuToggle) return;
+  if (menuToggle) {
+    document.addEventListener('click', (e) => {
+      if (!menuToggle.checked) return;
+      const header = document.querySelector('header');
+      if (header && !header.contains(e.target)) {
+        menuToggle.checked = false;
+      }
+    });
+  }
 
-  document.addEventListener('click', (e) => {
-    if (!menuToggle.checked) return;
-    const header = document.querySelector('header');
-    if (!header.contains(e.target)) {
-      menuToggle.checked = false;
+  const headerContainer = document.querySelector('header .container');
+  if (!headerContainer) return;
+
+  const themeButton = document.createElement('button');
+  themeButton.className = 'theme-toggle';
+  themeButton.setAttribute('aria-label', 'Toggle theme');
+
+  const setTheme = (theme) => {
+    if (theme === 'light') {
+      document.documentElement.setAttribute('data-theme', 'light');
+      themeButton.textContent = '🌙';
+    } else {
+      document.documentElement.removeAttribute('data-theme');
+      themeButton.textContent = '☀️';
     }
+  };
+
+  const storedTheme = localStorage.getItem('theme');
+  if (storedTheme) {
+    setTheme(storedTheme);
+  } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
+    setTheme('light');
+  } else {
+    setTheme('dark');
+  }
+
+  themeButton.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
+    const next = current === 'light' ? 'dark' : 'light';
+    setTheme(next);
+    localStorage.setItem('theme', next);
   });
+
+  const menuIcon = headerContainer.querySelector('.menu-icon');
+  headerContainer.insertBefore(themeButton, menuIcon);
+});
+

--- a/style.css
+++ b/style.css
@@ -79,7 +79,22 @@ header .container {
     height: 18px;
     position: relative;
     cursor: pointer;
+    margin-left: 0.5em;
+}
+
+.theme-toggle {
+    background: none;
+    border: none;
+    color: var(--accent-color);
+    cursor: pointer;
+    font-size: 1.2em;
     margin-left: auto;
+    transition: color 0.3s ease, transform 0.3s ease;
+}
+
+.theme-toggle:hover {
+    color: var(--text-color);
+    transform: rotate(20deg);
 }
 .menu-icon::before {
     content: "";
@@ -254,7 +269,7 @@ header .container {
     height: 18px;
     position: relative;
     cursor: pointer;
-    margin-left: auto;
+    margin-left: 0.5em;
 }
 .menu-icon::before {
     content: "";
@@ -1326,6 +1341,13 @@ details.press-item[open] + .press-subtitle {
     --border-color: #555555;
     --accent-color: #b3b3b3;
     --container-width: 800px;
+}
+
+:root[data-theme="light"] {
+    --background-color: #ffffff;
+    --text-color: #0a0a0a;
+    --border-color: #cccccc;
+    --accent-color: #333333;
 }
 
 html {


### PR DESCRIPTION
## Summary
- add light/dark theme toggle button and CSS variables
- adjust header spacing for new toggle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689badab3200832dbd4c5b3e6edabee6