### PR TITLE
Restore detailed works and project content

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -27,29 +27,22 @@
 <main id="main">
     <section>
         <h1>Biography</h1>
-        <p>Leonardo Matteucci is a composer exploring inner corporeality and the tactility of acoustic-electronic hybridisation.</p>
-        <p>His music investigates the mechanics of bodily articulation through acoustic and electronic means.</p>
+        <p><a href="/">Leonardo Matteucci</a> is a composer exploring inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation.</p>
+        <p>He studied composition with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> in Turin (2019-2021) and <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> in Fermo (2021-2023), and is currently pursuing a Master's degree under <a href="https://fr.wikipedia.org/wiki/Franck_Bedrossian" target="_blank">Franck Bedrossian</a> at <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
     </section>
 
     <section>
         <h2>Studies</h2>
         <ul>
-            <li>2023– – Master’s in Composition with Franck Bedrossian, Kunstuniversität Graz</li>
-            <li>2021–2023 – Composition studies with Marco Momi, Fermo Conservatory</li>
-            <li>2019–2021 – Composition studies with Giorgio Colombo Taccani, Turin Conservatory</li>
+            <li>2023– – Master’s in Composition with <a href="https://fr.wikipedia.org/wiki/Franck_Bedrossian" target="_blank">Franck Bedrossian</a>, <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a></li>
+            <li>2021–2023 – Composition studies with <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a>, Fermo Conservatory</li>
+            <li>2019–2021 – Composition studies with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a>, Turin Conservatory</li>
         </ul>
     </section>
 
     <section>
         <h2>Influences</h2>
         <p>Drawing from corporeal practices and electronic experimentation, his work seeks a tactile, physical engagement with sound.</p>
-    </section>
-
-    <section>
-        <h2>Awards</h2>
-        <ul>
-            <li>Placeholder Award, 2024</li>
-        </ul>
     </section>
 </main>
 <footer>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -131,3 +131,25 @@ footer {
     .hero h1 { font-size: 2.2rem; }
     .nav-list { flex-direction: column; gap: 12px; }
 }
+
+/* Legacy work/project styles restored from previous design */
+.italic { font-style: italic; }
+.align-center { text-align: center; }
+.align-right { text-align: right; }
+.works-title { font-size: 1.5rem; font-weight: 600; text-align: center; margin-bottom: 0.5em; }
+.works-details { color: var(--accent); }
+.duration { margin-bottom: 1em; }
+.instrumentation-list { list-style: none; padding: 0; text-align: center; }
+.instrumentation-list li { margin: 0.25em 0; }
+.gear-list, .gear-list-tight { list-style: none; padding: 0; }
+.gear-list li, .gear-list-tight li { margin: 0.25em 0; }
+.works-premiere { margin-top: 1em; }
+.works-separator, .works-separator-half, .works-separator-small { border: none; border-top: 1px solid var(--border); width: 50%; margin: 2em auto; }
+.works-separator-half { margin: 1.5em auto; }
+.works-separator-small { margin: 1em auto; }
+.translation-ita, .translation-eng { margin-left: 0; }
+.gray { color: var(--accent); }
+.link { text-decoration: underline; }
+.link:hover { color: var(--accent); }
+.no-italic { font-style: normal; }
+.regular { font-style: normal; }

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Home - Leonardo Matteucci</title>
-    <meta name="description" content="Composer exploring corporeality and acoustic-electronic hybridisation.">
+    <meta name="description" content="Born in Perugia, Italy, in 2000, Leonardo Matteucci is a composition student exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation. He studied in Turin with Giorgio Colombo Taccani from 2019 to 2021, and in Fermo with Marco Momi from 2021 to 2023. He is now pursuing his Master’s in Composition under Franck Bedrossian at the Kunstuniversität Graz.">
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
@@ -27,7 +27,7 @@
 <main id="main">
   <section class="hero">
     <h1>Leonardo Matteucci</h1>
-    <p>Composer exploring corporeality and acoustic-electronic hybridisation</p>
+    <p>Composer exploring inner corporeality, body mechanics and acoustic-electronic hybridisation</p>
     <a class="btn" href="/works/">Explore Works</a>
   </section>
 

--- a/projects/index.html
+++ b/projects/index.html
@@ -27,6 +27,7 @@
 <main id="main">
   <section class="latest-works">
     <h1>Projects</h1>
+    <p>Collaborative initiatives exploring corporeal mechanics and shared musical research.</p>
     <div class="works-grid">
       <article class="work-card">
         <h3><a href="/projects/reach-touch/">Reach.Touch.</a></h3>

--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -24,9 +24,71 @@
   </nav>
 </header>
 <main id="main">
-  <section class="latest-works">
-    <h1>Reach.Touch.</h1>
-    <p>Concert project exploring hidden bodily mechanics through works by Matteucci, Sarmiento, and Savagnone.</p>
+  <section class="reach-touch">
+    <h1 class="works-title">Reach.Touch. (2025)</h1>
+    <p class="works-details align-center duration">1h10′</p>
+    <p class="regular">Juan Sarmiento (*2002)</p>
+    <div class="about-text">
+      <p class="regular">Decir adiós (from <span class="italic">Widmung</span>)</p>
+      <p class="works-details italic mid-margin">for piano and electronics</p>
+    </div>
+    <div class="about-text">
+      <p class="regular">Black bells (from <span class="italic">Widmung</span>)</p>
+      <p class="works-details italic mid-margin">for piano</p>
+    </div>
+    <div class="about-text">
+      <p class="regular">White bells (from <span class="italic">Widmung</span>)</p>
+      <p class="works-details italic mid-margin">for piano and electronics</p>
+    </div>
+    <div class="about-text">
+      <p class="regular">Lindar algo con otro</p>
+      <p class="works-details italic">for piano</p>
+    </div>
+    <hr class="works-separator-half">
+    <p class="regular">Emanuele Savagnone (*1997)</p>
+    <div class="about-text">
+      <p class="regular">stars on black canvas</p>
+      <p class="works-details italic">for piano</p>
+    </div>
+    <p class="regular align-right gray intermission-text"><span class="italic">INTERMISSION</span></p>
+    <hr class="works-separator-small">
+    <p class="regular">Leonardo Matteucci (*2000)</p>
+    <div class="about-text">
+      <p class="regular"><a href="/works/assume/" class="link">Assume</a></p>
+      <p class="works-details italic">for piano, flute, cello and electronics</p>
+    </div>
+    <hr class="works-separator-half">
+    <p class="regular">Juan Sarmiento (*2002)</p>
+    <div class="about-text">
+      <p class="regular">Caminos (from <span class="italic">Widmung</span>)</p>
+      <p class="works-details italic mid-margin">for electronics</p>
+    </div>
+    <div class="about-text">
+      <p class="regular">Choral (from <span class="italic">Widmung</span>)</p>
+      <p class="works-details italic">for piano and electronics</p>
+    </div>
+    <hr class="works-separator-half">
+    <p class="regular">Leonardo Matteucci (*2000)</p>
+    <div class="about-text">
+      <p class="regular"><a href="/works/occlusion/" class="link">Occlusion</a></p>
+      <p class="works-details italic">for violin and electronics</p>
+    </div>
+    <hr class="works-separator">
+    <div class="about-text">
+      <p class="italic"><span style="font-style: normal;">Reach.Touch.</span> is a concert project whose themes focus on hidden bodily mechanics: movements that bend, compress, and collapse.</p>
+      <p class="italic">There are moments when the internal tensions of our bodies escape, manifesting directly through sound—raw emissions tracing the most direct path from interior to exterior, emerging precisely where musical articulation first takes shape. Here, sound reveals a humanity stripped of rhetoric, a bare caress of the body's inner movements.</p>
+      <p class="italic">This visceral intimacy—where touching implies reaching outward—has always represented, to me, an attempt at contact, at correspondence, or at least an affection driven by an urgent need to reach, a commitment to both the musicians' physical gestures and the internal bodily responses of the audience.</p>
+      <p class="italic">In this context—where musical articulation mirrors a physical gesture reaching outward, straining against its own sonic projection—amplification serves not only as a means to render perceptible what lingers unheard, what merely skims the skin, but also as a medium to empower intimacy. This intimacy communicates most clearly as one draws closer and closer to its source, until it touches the skin.</p>
+      <p class="italic">Dynamics, therefore, become less about physical intensity and more about unveiling the potency of gesture at its fullest—amplified to clarity without distortion or strain.</p>
+      <p class="italic">Intimacy demands proximity: listeners must lean in to discern between what is here and what is almost here, between what is touching and what is only attempting to reach. In this delicate space, what is fully present gradually meets what merely shimmers at the edge of perception—where neighboring domains touch without merging.</p>
+      <p class="align-right" style="font-style: normal;">Leonardo Matteucci</p>
+    </div>
+    <hr class="works-separator-small">
+    <p class="works-details italic align-right"><span class="regular link" style="font-style: normal;">Reach.Touch.</span> is a concert project supported by
+      <a href="https://www.land.steiermark.at/" target="_blank">Land Steiermark</a>,
+      the <a href="https://www.oehkug.at/" target="_blank">ÖH-KUG</a>, and
+      <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>
+    </p>
   </section>
 </main>
 <footer>

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -24,12 +24,36 @@
   </nav>
 </header>
 <main id="main">
-  <section class="hero">
-    <h1>A uno spirituale in Firenze</h1>
-    <p>2021 • string quartet and electronics</p>
-  </section>
-  <section class="latest-works">
-    <p>Premiered by Quartetto Maurice in Turin.</p>
+  <section>
+    <h1 class="works-title">A uno spirituale in Firenze (2021)</h1>
+    <p class="works-details align-center duration">5′</p>
+    <ul class="instrumentation-list large-margin">
+      <li>Violin I</li>
+      <li>Violin II</li>
+      <li>Viola</li>
+      <li>Cello</li>
+      <li>Electronics: fixed media (mono)
+        <span class="works-details italic">no instrumental amplification required</span>
+      </li>
+    </ul>
+    <p class="works-premiere premiere">Premiere: 29 October 2021, <span class="italic">Serate Musicali</span>, Turin Conservatory, Turin</p>
+    <hr class="works-separator">
+    <p class="italic">Five aphorisms inspired by an excerpt from the homonymous letter by Saint Catherine of Siena, addressed "to a devotee who was scandalized by her abstinences." This letter is taken from the second volume of a collection edited by Niccolò Tommaseo and published in Florence in 1860 by G. Barbèra.</p>
+    <p class="italic translation-ita"><span class="no-italic regular">1</span> «[…] e prego Dio e pregherò, che mi dia grazia che in quest’atto del mangiare io viva come le altre creature […]»</p>
+    <p class="no-italic translation-eng gray">"[…] and I pray and will continue to pray to God to grant me the grace to live, in this act of eating, as other creatures do […]"</p>
+    <p class="italic translation-ita"><span class="no-italic regular">2</span> «[…] e Dio che per singolarissima grazia m’abbia fatto correggere il vizio della gola […]»</p>
+    <p class="no-italic translation-eng gray">"[…] and God who, through a most singular grace, has allowed me to correct the vice of gluttony […]"</p>
+    <p class="italic translation-ita"><span class="no-italic regular">3a</span> «[…] Io per me non so che altro rimedio ponermici, … se non ch’io prego voi che preghiate quella somma eterna Verità […]»</p>
+    <p class="no-italic translation-eng gray">"[…] As for myself, I do not know what other remedy I can apply, except to ask you to pray to that supreme eternal Truth […]"</p>
+    <p class="italic translation-ita"><span class="no-italic regular">4</span> «E io son certa, che la bontà di Dio non spregierà le vostre orazioni.»</p>
+    <p class="no-italic translation-eng gray">"And I am certain that the goodness of God will not despise your prayers."</p>
+    <p class="italic translation-ita"><span class="no-italic regular">3b</span> «[…] che mi dia grazia, […] che mi faccia prendere il cibo, se gli piace.»</p>
+    <p class="no-italic translation-eng gray final">"[…] that He may grant me the grace […] to partake of food, if it pleases Him."</p>
+    <div class="soundcloud-player">
+      <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/a-uno-spirituale-in-firenze-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
+    </div>
+    <hr class="works-separator-small">
+    <p class="works-details italic align-right"><span class="regular link" style="font-style: normal;">A uno spirituale in Firenze</span> is dedicated to the memory of Carla Massini</p>
   </section>
 </main>
 <footer>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -24,12 +24,24 @@
   </nav>
 </header>
 <main id="main">
-  <section class="hero">
-    <h1>Assume</h1>
-    <p>2025 • piano, flute, cello and electronics</p>
-  </section>
-  <section class="latest-works">
-    <p>Part of the Reach.Touch. project.</p>
+  <section>
+    <h1 class="works-title">Assume (2025)</h1>
+    <p class="works-details align-center duration">15′</p>
+    <ul class="instrumentation-list large-margin">
+      <li>Piano</li>
+      <li>Flute</li>
+      <li>Cello</li>
+      <li>
+        Electronics: fixed media (5-channel)
+        <ul class="gear-list">
+          <li>3 audio exciters</li>
+          <li>2 cardioid condenser microphones</li>
+          <li>2 clip-on microphones</li>
+        </ul>
+      </li>
+    </ul>
+    <p class="works-premiere premiere">Premiere: 28 November 2025, KULTUM, [imCubus], Graz</p>
+    <hr class="works-separator">
   </section>
 </main>
 <footer>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -24,12 +24,36 @@
   </nav>
 </header>
 <main id="main">
-  <section class="hero">
-    <h1>Bodylines</h1>
-    <p>2023 • violin, piccolo and electronics</p>
-  </section>
-  <section class="latest-works">
-    <p>Exploration of corporeal gesture and breath.</p>
+  <section>
+    <h1 class="works-title">Bodylines (2023)</h1>
+    <p class="works-details align-center duration">7′30″</p>
+    <ul class="instrumentation-list large-margin">
+      <li>
+        Violin
+        <ul class="gear-list">
+          <li>Nebulizer tube</li>
+        </ul>
+      </li>
+      <li>
+        Piccolo
+        <ul class="gear-list">
+          <li>ACME Whistles<sup>®</sup> Silent Dog Whistle 535</li>
+        </ul>
+      </li>
+      <li>
+        Electronics: fixed media (5-channel)
+        <ul class="gear-list">
+          <li>3 audio exciters</li>
+          <li>1 contact microphone</li>
+          <li>1 lavalier microphone</li>
+        </ul>
+      </li>
+    </ul>
+    <hr class="works-separator">
+    <p class="italic">A transformed body needs a new representation: what persists are the lines in its movements; there is no musical semantics, only the need to move, to breathe within it.</p>
+    <div class="soundcloud-player">
+      <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/bodylines-home-studio-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
+    </div>
   </section>
 </main>
 <footer>

--- a/works/index.html
+++ b/works/index.html
@@ -29,6 +29,10 @@
     <h1>Works</h1>
     <div class="works-grid">
       <article class="work-card">
+        <h3>Dehiscence</h3>
+        <p>2026 • ensemble and electronics (upcoming)</p>
+      </article>
+      <article class="work-card">
         <h3><a href="/works/occlusion/">Occlusion</a></h3>
         <p>2025 • violin and electronics</p>
       </article>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -24,12 +24,48 @@
   </nav>
 </header>
 <main id="main">
-  <section class="hero">
-    <h1>Internal</h1>
-    <p>2023 • ensemble</p>
-  </section>
-  <section class="latest-works">
-    <p>Premiered by Opificio Sonoro at Festival Orizzonti.</p>
+  <section>
+    <h1 class="works-title">Internal (2023)</h1>
+    <p class="works-details align-center duration">10′</p>
+    <ul class="instrumentation-list large-margin">
+      <li>Flute (with B foot)</li>
+      <li>Clarinet in B<img src="../../logos/flat.svg" alt="flat" class="music-icon"></li>
+      <li>
+        Percussion
+        <ul class="gear-list gear-list-tight">
+          <li>Vibraphone</li>
+          <li>Crotales (F<img src="../../logos/sharp.svg" alt="sharp" class="music-icon">6,&nbsp;G<img src="../../logos/sharp.svg" alt="sharp" class="music-icon">6,&nbsp;A6,&nbsp;B6)</li>
+          <li>plectrum (medium)</li>
+        </ul>
+      </li>
+      <li>Guitar</li>
+      <li>
+        Piano
+        <ul class="gear-list">
+          <li>Heet Sound<sup>®</sup> EBow Plus</li>
+          <li>rubber hammer</li>
+          <li>plectrum (medium)</li>
+        </ul>
+      </li>
+      <li>Accordion</li>
+      <li>Violin</li>
+      <li>Cello</li>
+      <li>
+        Electronics (optional): fixed media (mono)
+        <ul class="gear-list">
+          <li>1 audio exciter</li>
+        </ul>
+        <span class="works-details italic">no instrumental amplification required</span>
+      </li>
+    </ul>
+    <p class="works-premiere premiere">Premiere: 11 May 2023, <span class="italic">Festival Orizzonti</span>, Auditorium Santa Cecilia, Perugia</p>
+    <hr class="works-separator">
+    <p class="italic">Establishing a relationship with what we cannot directly interact with: our bodily interior, the joints that emerge from within, contracting, bending, compressing; to better control, anticipate, or even break them, their flexions, and finally stretch them out.</p>
+    <div class="soundcloud-player">
+      <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/internal-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
+    </div>
+    <hr class="works-separator-small">
+    <p class="works-details italic align-right"><span class="regular link" style="font-style: normal;">Internal</span> was commissioned by and dedicated to <a href="https://www.opificiosonoro.com/" target="_blank">Opificio Sonoro</a></p>
   </section>
 </main>
 <footer>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -24,13 +24,21 @@
   </nav>
 </header>
 <main id="main">
-  <section class="hero">
-    <h1>Occlusion</h1>
-    <p>2025 • violin and electronics</p>
-  </section>
-  <section class="latest-works">
-    <p><strong>Premiere:</strong> 23 June 2025, Hermann-Markus-Preßl-Saal, Kunstuniversität Graz, Graz.</p>
-    <p class="italic">Occlusion is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward.</p>
+  <section>
+    <h1 class="works-title">Occlusion (2025)</h1>
+    <p class="works-details align-center duration">9′30″</p>
+    <ul class="instrumentation-list large-margin">
+      <li>Violin</li>
+      <li>
+        Electronics: fixed media (stereo)
+        <ul class="gear-list">
+          <li>1 clip-on microphone</li>
+        </ul>
+      </li>
+    </ul>
+    <p class="works-premiere premiere">Premiere: 23 June 2025, Hermann-Markus-Preßl-Saal, Kunstuniversität Graz, Graz</p>
+    <hr class="works-separator">
+    <p class="italic"><span class="no-italic">Occlusion</span> is the attempt to reach only to withdraw, where the body is constrained and the breath pulls downward. It closes, retreats, does not pass through. A breath that does not swell with air, but with touch. And so: reach again.</p>
   </section>
 </main>
 <footer>


### PR DESCRIPTION
## Summary
- Reinstate legacy style rules to support detailed work and project pages
- Restore comprehensive listings and program notes across Works and Reach.Touch. pages
- Add upcoming Dehiscence entry and project introduction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc9f7d724832d9b6febd4bcddae3a