### PR TITLE
Restore card layout and mobile-only menu

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -24,6 +24,31 @@ header {
     border-bottom: 1px solid var(--border);
     z-index: 1000;
 }
+
+#menu-toggle { display: none; }
+.menu-icon {
+    display: none;
+    flex-direction: column;
+    gap: 6px;
+    padding: 16px;
+    cursor: pointer;
+}
+.menu-icon span {
+    width: 24px;
+    height: 2px;
+    background: var(--fg);
+    transition: transform .3s, opacity .3s;
+}
+#menu-toggle:checked + .menu-icon span:nth-child(1) {
+    transform: translateY(8px) rotate(45deg);
+}
+#menu-toggle:checked + .menu-icon span:nth-child(2) {
+    opacity: 0;
+}
+#menu-toggle:checked + .menu-icon span:nth-child(3) {
+    transform: translateY(-8px) rotate(-45deg);
+}
+
 .nav-list {
     list-style: none;
     margin: 0;
@@ -62,12 +87,13 @@ header {
 }
 
 .hero {
-    background: url('/assets/img/hero.jpg') center/cover no-repeat;
     text-align: center;
     padding: 120px 16px;
     color: var(--fg);
 }
 .hero h1 { font-size: 3rem; margin-bottom: 16px; }
+.hero img { width: 200px; border-radius: 50%; margin: 24px auto; display: block; }
+.tagline { text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 24px; }
 .hero p { font-size: 1.2rem; margin-bottom: 24px; max-width: 600px; margin-left: auto; margin-right: auto; }
 .btn {
     display: inline-block;
@@ -79,6 +105,12 @@ header {
 }
 .btn:hover { background: #777; }
 
+.separator {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 64px auto;
+    width: 60%;
+}
 .latest-works, .upcoming-event { padding: 80px 16px; }
 .latest-works h2, .upcoming-event h2 { text-align: center; margin-bottom: 32px; }
 .works-grid {
@@ -129,7 +161,13 @@ footer {
 @media (max-width: 768px) {
     .hero { padding: 80px 12px; }
     .hero h1 { font-size: 2.2rem; }
-    .nav-list { flex-direction: column; gap: 12px; }
+}
+
+@media (max-width: 600px) {
+    .menu-icon { display: flex; }
+    nav { display: none; }
+    #menu-toggle:checked + .menu-icon + nav { display: block; }
+    .nav-list { flex-direction: column; gap: 12px; padding: 16px; }
 }
 
 /* Legacy work/project styles restored from previous design */

--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
+  <input type="checkbox" id="menu-toggle" class="menu-toggle">
+  <label for="menu-toggle" class="menu-icon" aria-label="Toggle menu">
+    <span></span>
+    <span></span>
+    <span></span>
+  </label>
   <nav>
     <ul class="nav-list">
       <li><a href="/" class="active">Home</a></li>
@@ -27,31 +33,36 @@
 <main id="main">
   <section class="hero">
     <h1>Leonardo Matteucci</h1>
-    <p>Composer exploring inner corporeality, body mechanics and acoustic-electronic hybridisation</p>
+    <img src="/graphics/photo-LC-pro_pic-bw.jpg" alt="Portrait of Leonardo Matteucci">
+    <p class="tagline">Composer exploring inner corporeality, body mechanics and acoustic-electronic hybridisation</p>
     <a class="btn" href="/works/">Explore Works</a>
   </section>
+
+  <hr class="separator">
 
   <section class="latest-works">
     <h2>Latest Works</h2>
     <div class="works-grid">
       <article class="work-card">
-        <h3>Occlusion (2025)</h3>
-        <p>Violin and electronics</p>
+        <h3>Occlusion<span class="works-details">2025</span></h3>
+        <p>violin and electronics</p>
         <a href="/works/occlusion/">More details</a>
       </article>
       <article class="work-card">
-        <h3>Assume (2025)</h3>
-        <p>Piano, flute, cello and electronics</p>
+        <h3>Assume<span class="works-details">2025</span></h3>
+        <p>piano, flute, cello and electronics</p>
         <a href="/works/assume/">More details</a>
       </article>
       <article class="work-card">
-        <h3>Bodylines (2023)</h3>
-        <p>Violin, piccolo and electronics</p>
+        <h3>Bodylines<span class="works-details">2023</span></h3>
+        <p>violin, piccolo and electronics</p>
         <a href="/works/bodylines/">More details</a>
       </article>
     </div>
     <a class="btn secondary" href="/works/">View all works</a>
   </section>
+
+  <hr class="separator">
 
   <section class="upcoming-event">
     <h2>Upcoming Event</h2>


### PR DESCRIPTION
## Summary
- Reinstate card-based layout for latest works and upcoming event with separators and CTA.
- Add mobile-only hamburger menu and hero image with uppercase tagline.
- Style updates: buttons, grid cards, separator, and responsive menu behavior.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c38fe6c2c832d981d5d47a82bbc27