### PR TITLE
Use white logo icons and update favicon paths

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -9,13 +9,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
     <!-- Site favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/lm-logo-favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
   <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
-  <a href="/" class="logo"><img src="/assets/icons/lm-logo-favicon.svg" alt="LM logo"></a>
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
   <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS -->
   <input type="checkbox" id="menu-toggle">
   <label class="menu-icon" for="menu-toggle">
@@ -55,9 +55,9 @@
 <footer>
   <p>© 2025 Leonardo Matteucci</p>
   <ul class="social-links">
-    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/icons/soundcloud.svg" alt="SoundCloud logo"></a></li>
-    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/icons/youtube.svg" alt="YouTube logo"></a></li>
-    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/icons/instagram.svg" alt="Instagram logo"></a></li>
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
 </body>

--- a/contact/index.html
+++ b/contact/index.html
@@ -9,13 +9,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
     <!-- Site favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/lm-logo-favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
   <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
-  <a href="/" class="logo"><img src="/assets/icons/lm-logo-favicon.svg" alt="LM logo"></a>
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
   <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS -->
   <input type="checkbox" id="menu-toggle">
   <label class="menu-icon" for="menu-toggle">
@@ -54,9 +54,9 @@
 <footer>
   <p>© 2025 Leonardo Matteucci</p>
   <ul class="social-links">
-    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/icons/soundcloud.svg" alt="SoundCloud logo"></a></li>
-    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/icons/youtube.svg" alt="YouTube logo"></a></li>
-    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/icons/instagram.svg" alt="Instagram logo"></a></li>
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
 </body>

--- a/events/index.html
+++ b/events/index.html
@@ -9,13 +9,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
     <!-- Site favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/lm-logo-favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
   <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
-  <a href="/" class="logo"><img src="/assets/icons/lm-logo-favicon.svg" alt="LM logo"></a>
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
   <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS -->
   <input type="checkbox" id="menu-toggle">
   <label class="menu-icon" for="menu-toggle">
@@ -75,9 +75,9 @@
 <footer>
   <p>© 2025 Leonardo Matteucci</p>
   <ul class="social-links">
-    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/icons/soundcloud.svg" alt="SoundCloud logo"></a></li>
-    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/icons/youtube.svg" alt="YouTube logo"></a></li>
-    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/icons/instagram.svg" alt="Instagram logo"></a></li>
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
 </body>

--- a/index.html
+++ b/index.html
@@ -9,13 +9,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
     <!-- Site favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/lm-logo-favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
   <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
-  <a href="/" class="logo"><img src="/assets/icons/lm-logo-favicon.svg" alt="LM logo"></a>
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
   <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS. -->
   <input type="checkbox" id="menu-toggle">
   <label class="menu-icon" for="menu-toggle">
@@ -89,9 +89,9 @@
 <footer>
   <p>© 2025 Leonardo Matteucci</p>
   <ul class="social-links">
-    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/icons/soundcloud.svg" alt="SoundCloud logo"></a></li>
-    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/icons/youtube.svg" alt="YouTube logo"></a></li>
-    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/icons/instagram.svg" alt="Instagram logo"></a></li>
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
 </body>

--- a/photos/index.html
+++ b/photos/index.html
@@ -9,13 +9,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
     <!-- Site favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/lm-logo-favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
   <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
-  <a href="/" class="logo"><img src="/assets/icons/lm-logo-favicon.svg" alt="LM logo"></a>
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
   <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS -->
   <input type="checkbox" id="menu-toggle">
   <label class="menu-icon" for="menu-toggle">
@@ -72,9 +72,9 @@
 <footer>
   <p>© 2025 Leonardo Matteucci</p>
   <ul class="social-links">
-    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/icons/soundcloud.svg" alt="SoundCloud logo"></a></li>
-    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/icons/youtube.svg" alt="YouTube logo"></a></li>
-    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/icons/instagram.svg" alt="Instagram logo"></a></li>
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
 </body>

--- a/projects/index.html
+++ b/projects/index.html
@@ -9,13 +9,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
     <!-- Site favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/lm-logo-favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
   <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
-  <a href="/" class="logo"><img src="/assets/icons/lm-logo-favicon.svg" alt="LM logo"></a>
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
   <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS -->
   <input type="checkbox" id="menu-toggle">
   <label class="menu-icon" for="menu-toggle">
@@ -54,9 +54,9 @@
 <footer>
   <p>© 2025 Leonardo Matteucci</p>
   <ul class="social-links">
-    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/icons/soundcloud.svg" alt="SoundCloud logo"></a></li>
-    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/icons/youtube.svg" alt="YouTube logo"></a></li>
-    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/icons/instagram.svg" alt="Instagram logo"></a></li>
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
 </body>

--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -9,13 +9,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
     <!-- Site favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/lm-logo-favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
   <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
-  <a href="/" class="logo"><img src="/assets/icons/lm-logo-favicon.svg" alt="LM logo"></a>
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
   <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS -->
   <input type="checkbox" id="menu-toggle">
   <label class="menu-icon" for="menu-toggle">
@@ -91,9 +91,9 @@
 <footer>
   <p>© 2025 Leonardo Matteucci</p>
   <ul class="social-links">
-    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/icons/soundcloud.svg" alt="SoundCloud logo"></a></li>
-    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/icons/youtube.svg" alt="YouTube logo"></a></li>
-    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/icons/instagram.svg" alt="Instagram logo"></a></li>
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
 </body>

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -9,13 +9,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
     <!-- Site favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/lm-logo-favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
   <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
-  <a href="/" class="logo"><img src="/assets/icons/lm-logo-favicon.svg" alt="LM logo"></a>
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
   <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS -->
   <input type="checkbox" id="menu-toggle">
   <label class="menu-icon" for="menu-toggle">
@@ -70,9 +70,9 @@
 <footer>
   <p>© 2025 Leonardo Matteucci</p>
   <ul class="social-links">
-    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/icons/soundcloud.svg" alt="SoundCloud logo"></a></li>
-    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/icons/youtube.svg" alt="YouTube logo"></a></li>
-    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/icons/instagram.svg" alt="Instagram logo"></a></li>
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
 </body>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -9,13 +9,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
     <!-- Site favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/lm-logo-favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
   <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
-  <a href="/" class="logo"><img src="/assets/icons/lm-logo-favicon.svg" alt="LM logo"></a>
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
   <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS -->
   <input type="checkbox" id="menu-toggle">
   <label class="menu-icon" for="menu-toggle">
@@ -61,9 +61,9 @@
 <footer>
   <p>© 2025 Leonardo Matteucci</p>
   <ul class="social-links">
-    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/icons/soundcloud.svg" alt="SoundCloud logo"></a></li>
-    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/icons/youtube.svg" alt="YouTube logo"></a></li>
-    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/icons/instagram.svg" alt="Instagram logo"></a></li>
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
 </body>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -9,13 +9,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
     <!-- Site favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/lm-logo-favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
   <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
-  <a href="/" class="logo"><img src="/assets/icons/lm-logo-favicon.svg" alt="LM logo"></a>
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
   <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS -->
   <input type="checkbox" id="menu-toggle">
   <label class="menu-icon" for="menu-toggle">
@@ -70,9 +70,9 @@
 <footer>
   <p>© 2025 Leonardo Matteucci</p>
   <ul class="social-links">
-    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/icons/soundcloud.svg" alt="SoundCloud logo"></a></li>
-    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/icons/youtube.svg" alt="YouTube logo"></a></li>
-    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/icons/instagram.svg" alt="Instagram logo"></a></li>
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
 </body>

--- a/works/index.html
+++ b/works/index.html
@@ -9,13 +9,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
     <!-- Site favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/lm-logo-favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
   <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
-  <a href="/" class="logo"><img src="/assets/icons/lm-logo-favicon.svg" alt="LM logo"></a>
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
   <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS -->
   <input type="checkbox" id="menu-toggle">
   <label class="menu-icon" for="menu-toggle">
@@ -80,9 +80,9 @@
 <footer>
   <p>© 2025 Leonardo Matteucci</p>
   <ul class="social-links">
-    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/icons/soundcloud.svg" alt="SoundCloud logo"></a></li>
-    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/icons/youtube.svg" alt="YouTube logo"></a></li>
-    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/icons/instagram.svg" alt="Instagram logo"></a></li>
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
 </body>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -8,13 +8,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
     <!-- Site favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/lm-logo-favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
   <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
-  <a href="/" class="logo"><img src="/assets/icons/lm-logo-favicon.svg" alt="LM logo"></a>
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
   <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS -->
   <input type="checkbox" id="menu-toggle">
   <label class="menu-icon" for="menu-toggle">
@@ -84,9 +84,9 @@
 <footer>
   <p>© 2025 Leonardo Matteucci</p>
   <ul class="social-links">
-    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/icons/soundcloud.svg" alt="SoundCloud logo"></a></li>
-    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/icons/youtube.svg" alt="YouTube logo"></a></li>
-    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/icons/instagram.svg" alt="Instagram logo"></a></li>
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
 </body>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -9,13 +9,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
     <!-- Site favicon -->
-    <link rel="icon" type="image/svg+xml" href="/assets/icons/lm-logo-favicon.svg">
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
 <header>
   <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
-  <a href="/" class="logo"><img src="/assets/icons/lm-logo-favicon.svg" alt="LM logo"></a>
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
   <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS -->
   <input type="checkbox" id="menu-toggle">
   <label class="menu-icon" for="menu-toggle">
@@ -58,9 +58,9 @@
 <footer>
   <p>© 2025 Leonardo Matteucci</p>
   <ul class="social-links">
-    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/icons/soundcloud.svg" alt="SoundCloud logo"></a></li>
-    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/icons/youtube.svg" alt="YouTube logo"></a></li>
-    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/icons/instagram.svg" alt="Instagram logo"></a></li>
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
 </body>


### PR DESCRIPTION
## Summary
- Swap social media icon references for white logo versions under `/assets/logos/`.
- Point all favicon references to `/assets/logos/lm-logo-favicon.svg` for consistency.

## Testing
- `pytest -q` *(fails: Missing paths referenced in sitemap: ['press-kit'])*

------
https://chatgpt.com/codex/tasks/task_e_689e484a492c832daf5cd1cf13f9ee2c