### PR TITLE
fix: remove invert filter from footer icons

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -502,14 +502,11 @@ figure.work-card figcaption {
   height: 21px;
   display: block;
   opacity: 0.8;
-  /* invert icons for dark theme */
-  filter: invert(1) grayscale(100%);
-  transition: opacity 0.2s, transform 0.2s, filter 0.2s;
+  transition: opacity 0.2s, transform 0.2s;
 }
 .social-links a:hover img {
   opacity: 1;
   transform: translateY(-2px);
-  filter: invert(1) grayscale(0%);
 }
 
 /* Logo styling */


### PR DESCRIPTION
## Summary
- show footer social icons by removing dark-theme invert filter

## Testing
- `pytest -q` *(fails: Missing paths referenced in sitemap: ['press-kit'])*

------
https://chatgpt.com/codex/tasks/task_e_689e4a0dac4c832da350ec55bb4ba33e