### PR TITLE
Improve mobile navigation and add press kit placeholder

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -622,11 +622,13 @@ footer {
   height: 2px;
   margin: 4px 0;
   background: var(--fg);
+  transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
 @media (max-width: 768px) {
   /* Reset header layout on small screens */
   header {
+    flex-direction: row;
     justify-content: space-between;
     align-items: center;
     padding: 12px 16px;
@@ -635,46 +637,63 @@ footer {
   .menu-icon {
     display: block;
   }
-  /* Hide the navigation by default */
+  /* Full-screen nav overlay hidden off-canvas */
   header nav {
-    display: none;
-    position: absolute;
-    top: 56px;
-    right: 16px;
-    background: #111111;
-    border-radius: 12px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
-    min-width: 200px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    background: var(--bg);
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 80px 24px 24px;
+    transform: translateY(-100%);
+    transition: transform 0.3s ease-in-out;
     z-index: 1000;
+    pointer-events: none;
   }
-  /* Display the nav when the toggle is checked */
+  /* Slide the nav into view when toggled */
   #menu-toggle:checked + label.menu-icon + nav {
-    display: block;
+    transform: translateY(0);
+    pointer-events: auto;
   }
-  /* Style nav list inside the mobile panel */
+  /* Mobile nav list */
   header nav ul.nav-list {
     flex-direction: column;
-    gap: 0;
-    padding: 8px 0;
+    gap: 24px;
+    padding: 0;
     margin: 0;
+    width: 100%;
   }
   header nav ul.nav-list li {
     width: 100%;
-    border-bottom: 1px solid var(--border);
-    text-align: left;
-    padding: 0 16px;
-  }
-  header nav ul.nav-list li:last-child {
-    border-bottom: none;
   }
   header nav ul.nav-list li a {
     display: block;
-    padding: 10px 0;
+    width: 100%;
+    padding: 12px 0;
+    text-align: left;
+  }
+  /* Animate hamburger into an X when open */
+  #menu-toggle:checked + label.menu-icon span:nth-child(1) {
+    transform: translateY(6px) rotate(45deg);
+  }
+  #menu-toggle:checked + label.menu-icon span:nth-child(2) {
+    opacity: 0;
+  }
+  #menu-toggle:checked + label.menu-icon span:nth-child(3) {
+    transform: translateY(-6px) rotate(-45deg);
   }
   /* Position the logo relatively so it participates in the normal flow */
   .logo {
     position: static;
     margin: 0;
+  }
+  /* Hero content left aligned on mobile */
+  .hero {
+    text-align: left;
   }
 }
 

--- a/press-kit/index.html
+++ b/press-kit/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Press Kit - Leonardo Matteucci</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/assets/css/style.css">
+    <!-- Site favicon -->
+    <link rel="icon" type="image/svg+xml" href="/assets/logos/lm-logo-favicon.svg">
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<header>
+  <!-- Logo appears first so it stays left aligned on large screens and centres above the nav on mobile -->
+  <a href="/" class="logo"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a>
+  <!-- Mobile navigation toggle (three bars). Hidden on large screens via CSS -->
+  <input type="checkbox" id="menu-toggle">
+  <label class="menu-icon" for="menu-toggle">
+    <span></span>
+    <span></span>
+    <span></span>
+  </label>
+  <nav>
+    <ul class="nav-list">
+      <li><a href="/">Home</a></li>
+      <li><a href="/about/">About</a></li>
+      <li><a href="/projects/">Projects</a></li>
+      <li><a href="/works/">Works</a></li>
+      <li><a href="/photos/">Photos</a></li>
+      <li><a href="/events/">Events</a></li>
+      <li><a href="/contact/">Contact</a></li>
+    </ul>
+  </nav>
+</header>
+<main id="main">
+  <div class="container">
+    <section>
+      <h1 class="works-title">Press Kit</h1>
+      <p>Press kit coming soon.</p>
+    </section>
+  </div>
+</main>
+<footer>
+  <p>© 2025 Leonardo Matteucci</p>
+  <ul class="social-links">
+    <li><a href="https://soundcloud.com/leonardo_matteucci" aria-label="SoundCloud" target="_blank"><img src="/assets/logos/soundcloud-logo_white.svg" alt="SoundCloud logo"></a></li>
+    <li><a href="https://www.youtube.com/@leonardo_matteucci" aria-label="YouTube" target="_blank"><img src="/assets/logos/youtube-logo_white.svg" alt="YouTube logo"></a></li>
+    <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
+  </ul>
+</footer>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- Animate hamburger icon into an X and slide mobile nav in as a full-screen panel
- Left-align hero section on small screens
- Add placeholder press kit page referenced by the sitemap

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e4da4485c832dab059ef9bba69c4d