### PR TITLE
Center homepage tagline

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -287,6 +287,7 @@ nav {
   font-style: normal;
   font-weight: 300;
   letter-spacing: 0.1em;
+  text-align: center;
   margin-top: 16px;
   margin-bottom: 32px;
   opacity: 0.9;


### PR DESCRIPTION
## Summary
- ensure home page "Composer" tagline stays centered by adding explicit text alignment.

## Testing
- `python3 - <<'PY'
import tests.test_sitemap as t
try:
    t.test_sitemap_paths_exist()
    print('test_sitemap_paths_exist passed')
except AssertionError as e:
    print('AssertionError:', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689e4f87a6a8832d9ae195b371b76125