### PR TITLE
Reduce vertical spacing above mobile nav menu

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -648,7 +648,10 @@ footer {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    padding: 80px 24px 24px;
+    /* Reduce the top padding so the first menu item appears
+       closer to the top on mobile. The previous value left a
+       large blank space above the navigation links. */
+    padding: 56px 24px 24px;
     transform: translateY(-100%);
     transition: transform 0.3s ease-in-out;
     z-index: 1000;


### PR DESCRIPTION
## Summary
- lower top padding on mobile nav overlay so menu items display without excessive gap

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e4fb9e360832db1af5e1243fb4bf2