### PR TITLE
feat: fill hero logo on hover

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -161,6 +161,11 @@ nav {
   max-width: 100%;
   width: clamp(160px, 28vw, 80px);
   opacity: 0.5;
+  transition: opacity 0.3s;
+}
+
+.hero-logo:hover {
+  opacity: 1;
 }
 
 /* Hide the portrait overlay on the hero section for a cleaner introduction */

--- a/assets/logos/lm-logo-thinlines.svg
+++ b/assets/logos/lm-logo-thinlines.svg
@@ -7,6 +7,11 @@
         stroke: #fff;
         stroke-miterlimit: 10;
         stroke-width: 3px;
+        transition: fill 0.3s;
+      }
+
+      svg:hover .cls-1 {
+        fill: #fff;
       }
     </style>
   </defs>


### PR DESCRIPTION
## Summary
- fill thin-line homepage logo when hovered
- animate hero logo opacity on hover

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f92ff4b3c832d9056aca3c2fc430c