### PR TITLE
Add elegant image preview modal

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -42,7 +42,7 @@
           <p>He studied composition with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> in Turin (2019–2021) and <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> in Fermo (2021–2023), and is currently pursuing a Master's degree under <a href="https://fr.wikipedia.org/wiki/Franck_Bedrossian" target="_blank">Franck Bedrossian</a> at <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
         </div>
         <div class="about-photo">
-          <img src="/assets/graphics/photo-LC-1-bw.jpg" alt="Portrait of Leonardo Matteucci" loading="lazy">
+          <img src="/assets/graphics/photo-LC-1-bw.jpg" alt="Portrait of Leonardo Matteucci" loading="lazy" data-enlargeable>
         </div>
       </div>
     </section>
@@ -56,5 +56,6 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/photo-preview.js" defer></script>
 </body>
 </html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -793,3 +793,35 @@ main{
 }
 
 html, body{ overflow-x: hidden; } /* opzionale */
+
+/* Image preview modal */
+.image-modal{
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.9);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10000;
+  animation: fadeIn 0.3s ease;
+}
+
+.image-modal img{
+  max-width: 90%;
+  max-height: 90%;
+  box-shadow: 0 0 16px rgba(0,0,0,0.5);
+}
+
+.image-modal-close{
+  position: absolute;
+  top: 16px;
+  right: 24px;
+  font-size: 2rem;
+  color: var(--fg);
+  cursor: pointer;
+}
+
+@keyframes fadeIn{
+  from{ opacity: 0; }
+  to{ opacity: 1; }
+}

--- a/photo-preview.js
+++ b/photo-preview.js
@@ -1,0 +1,25 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const images = document.querySelectorAll('img[data-enlargeable]');
+  images.forEach(img => {
+    img.style.cursor = 'zoom-in';
+    img.addEventListener('click', () => {
+      const modal = document.createElement('div');
+      modal.className = 'image-modal';
+      modal.innerHTML = `<span class="image-modal-close" aria-label="Close">&times;</span><img src="${img.src}" alt="${img.alt}">`;
+      document.body.appendChild(modal);
+
+      const remove = () => modal.remove();
+      modal.addEventListener('click', e => {
+        if (e.target === modal || e.target.classList.contains('image-modal-close')) {
+          remove();
+        }
+      });
+      document.addEventListener('keydown', function handler(e) {
+        if (e.key === 'Escape') {
+          remove();
+          document.removeEventListener('keydown', handler);
+        }
+      });
+    });
+  });
+});

--- a/photos/index.html
+++ b/photos/index.html
@@ -38,27 +38,27 @@
       <h1 class="works-title">Photos</h1>
       <div class="works-grid">
         <figure class="work-card">
-          <img src="../assets/graphics/photo-LC-1-bw.jpg" alt="Portrait 1" loading="lazy">
+          <img src="../assets/graphics/photo-LC-1-bw.jpg" alt="Portrait 1" loading="lazy" data-enlargeable>
           <figcaption>© Lorenzo Chiacchieroni</figcaption>
         </figure>
         <figure class="work-card">
-          <img src="../assets/graphics/photo-LC-4-bw.jpg" alt="Portrait 4" loading="lazy">
+          <img src="../assets/graphics/photo-LC-4-bw.jpg" alt="Portrait 4" loading="lazy" data-enlargeable>
           <figcaption>© Lorenzo Chiacchieroni</figcaption>
         </figure>
         <figure class="work-card">
-          <img src="../assets/graphics/photo-LC-5-bw.jpg" alt="Portrait 5" loading="lazy">
+          <img src="../assets/graphics/photo-LC-5-bw.jpg" alt="Portrait 5" loading="lazy" data-enlargeable>
           <figcaption>© Lorenzo Chiacchieroni</figcaption>
         </figure>
         <figure class="work-card">
-          <img src="../assets/graphics/photo-LC-3-bw.jpg" alt="Portrait 3" loading="lazy">
+          <img src="../assets/graphics/photo-LC-3-bw.jpg" alt="Portrait 3" loading="lazy" data-enlargeable>
           <figcaption>© Lorenzo Chiacchieroni</figcaption>
         </figure>
         <figure class="work-card">
-          <img src="../assets/graphics/photo-LC-8-bw.jpg" alt="Portrait 8" loading="lazy">
+          <img src="../assets/graphics/photo-LC-8-bw.jpg" alt="Portrait 8" loading="lazy" data-enlargeable>
           <figcaption>© Lorenzo Chiacchieroni</figcaption>
         </figure>
         <figure class="work-card">
-          <img src="../assets/graphics/photo-LC-pro_pic-bw.jpg" alt="Portrait profile" loading="lazy">
+          <img src="../assets/graphics/photo-LC-pro_pic-bw.jpg" alt="Portrait profile" loading="lazy" data-enlargeable>
           <figcaption>© Lorenzo Chiacchieroni</figcaption>
         </figure>
       </div>
@@ -73,5 +73,6 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/photo-preview.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add `photo-preview.js` to show clicked images in a centered modal overlay with close support.
- Style modal with full-screen dark backdrop and responsive sizing.
- Mark gallery and portrait images as enlargeable and load the script on those pages.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f7f5a3e8832d87db0425c1b0fcf6