### PR TITLE
Restrict photo preview to site width

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -815,8 +815,12 @@ html, body{ overflow-x: hidden; } /* opzionale */
 }
 
 .image-modal img{
-  max-width: 90%;
-  max-height: 90%;
+  /* Limit enlarged photos to the site width and the viewport */
+  display: block;
+  width: auto;
+  height: auto;
+  max-width: min(90vw, 1000px);
+  max-height: 90vh;
   box-shadow: 0 0 16px rgba(0,0,0,0.5);
 }
 


### PR DESCRIPTION
## Summary
- Limit modal photo previews to the viewport and site width for better responsiveness

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f9da6840832d9ff4288bd57681a4