### PR TITLE
Match contact send button typography to home page buttons

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -199,6 +199,7 @@ nav{
   color: #fff;
   border-radius: 4px;
   transition: background-color 0.2s, color 0.2s; /* fixed */
+  font: inherit; /* ensure buttons match link typography */
 }
 
 .btn.secondary{


### PR DESCRIPTION
## Summary
- ensure `.btn` elements inherit site fonts so contact form "Send" button matches home page buttons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1b56d01e0832d90ee21760925223a