### PR TITLE
Fix work page spacing and accessibility

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -607,6 +607,11 @@ section{
   margin-bottom: 48px;
 }
 
+/* Ensure the first section on a page aligns with the top content area */
+main > :first-child > section:first-of-type{
+  margin-top: 0;
+}
+
 /* Uniform heading spacing for sections */
 section > h1, section > h2{
   text-align: center;

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -62,7 +62,7 @@
       <hr class="separator">
       <p class="italic">A transformed body needs a new representation: what persists are the lines in its movements; there is no musical semantics, only the need to move, to breathe within it.</p>
       <div class="soundcloud-player">
-      <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/internal-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
+      <iframe title="SoundCloud player for Bodylines" loading="lazy" width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/internal-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
       </div>
     </section>
   </div>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Internal - Leonardo Matteucci</title>
+    <meta name="description" content="Internal by Leonardo Matteucci with instrumentation, program note and premiere information.">
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/css/style.css">
@@ -36,7 +37,7 @@
     <section>
       <h1 class="works-title">Internal<span class="works-details">2023</span></h1>
       <p class="works-details align-center duration">10′</p>
-      <ul class="instrumentation-list large-margin">
+      <ul class="instrumentation-list">
         <li>Flute (with B foot)</li>
         <li>Clarinet in B♭</li>
         <li>
@@ -71,7 +72,7 @@
       <hr class="separator">
       <p class="italic">Establishing a relationship with what we cannot directly interact with: our bodily interior, the joints that emerge from within, contracting, bending, compressing; to better control, anticipate, or even break them, their flexions, and finally stretch them out.</p>
       <div class="soundcloud-player">
-        <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/internal-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
+        <iframe title="SoundCloud player for Internal" loading="lazy" width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/leonardo_matteucci/internal-live-recording/&color=%23ff5500&auto_play=false&show_user=true"></iframe>
       </div>
       <p class="works-details italic align-right"><a href="/works/internal/index.html">Internal</a> was commissioned by and dedicated to <a href="https://www.opificiosonoro.com/" target="_blank">Opificio Sonoro</a></p>
     </section>


### PR DESCRIPTION
## Summary
- Align section layout so first sections start uniformly across pages
- Add meta description and clean up Internal work page markup
- Improve SoundCloud embeds with titles and lazy loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1d0b3df1c832d8e3fc28cdb057638