### PR TITLE
Prevent scrolling when mobile menu is open

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -57,6 +57,7 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/menu.js" defer></script>
 <script src="/photo-preview.js" defer></script>
 </body>
 </html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -58,6 +58,7 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/menu.js" defer></script>
 <script src="/contact-form.js"></script>
 </body>
 </html>

--- a/events/index.html
+++ b/events/index.html
@@ -81,5 +81,6 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/menu.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -90,5 +90,6 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/menu.js" defer></script>
 </body>
 </html>

--- a/menu.js
+++ b/menu.js
@@ -2,11 +2,19 @@ window.addEventListener('DOMContentLoaded', () => {
   const menuToggle = document.getElementById('menu-toggle');
   if (!menuToggle) return;
 
+  const updateScrollLock = () => {
+    document.body.style.overflow = menuToggle.checked ? 'hidden' : '';
+  };
+
+  menuToggle.addEventListener('change', updateScrollLock);
+
   document.addEventListener('click', (e) => {
     if (!menuToggle.checked) return;
     const header = document.querySelector('header');
     if (!header.contains(e.target)) {
       menuToggle.checked = false;
+      updateScrollLock();
     }
   });
+  updateScrollLock();
 });

--- a/photos/index.html
+++ b/photos/index.html
@@ -74,6 +74,7 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/menu.js" defer></script>
 <script src="/photo-preview.js" defer></script>
 </body>
 </html>

--- a/projects/index.html
+++ b/projects/index.html
@@ -55,5 +55,6 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/menu.js" defer></script>
 </body>
 </html>

--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -94,5 +94,6 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/menu.js" defer></script>
 </body>
 </html>

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -73,5 +73,6 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/menu.js" defer></script>
 </body>
 </html>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -64,5 +64,6 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/menu.js" defer></script>
 </body>
 </html>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -76,5 +76,6 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/menu.js" defer></script>
 </body>
 </html>

--- a/works/index.html
+++ b/works/index.html
@@ -79,5 +79,6 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/menu.js" defer></script>
 </body>
 </html>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -87,5 +87,6 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/menu.js" defer></script>
 </body>
 </html>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -61,5 +61,6 @@
     <li><a href="https://www.instagram.com/leonardo_matteucci_ig" aria-label="Instagram" target="_blank"><img src="/assets/logos/instagram-logo_white.svg" alt="Instagram logo"></a></li>
   </ul>
 </footer>
+<script src="/menu.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- lock page scroll based on the mobile menu toggle
- load the shared menu script on every page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1ecac10a0832d873a04f5668cbf17