### PR TITLE
Use thinlines logo in navigation menu

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -22,7 +22,7 @@
   </label>
   <nav>
     <ul class="nav-list">
-      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a></li>
+      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-thinlines.svg" alt="LM logo"></a></li>
       <li><a href="/">Home</a></li>
       <li><a href="/about/" class="active">About</a></li>
       <li><a href="/projects/">Projects</a></li>

--- a/contact/index.html
+++ b/contact/index.html
@@ -22,7 +22,7 @@
   </label>
   <nav>
     <ul class="nav-list">
-      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a></li>
+      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-thinlines.svg" alt="LM logo"></a></li>
       <li><a href="/">Home</a></li>
       <li><a href="/about/">About</a></li>
       <li><a href="/projects/">Projects</a></li>

--- a/events/index.html
+++ b/events/index.html
@@ -22,7 +22,7 @@
   </label>
   <nav>
     <ul class="nav-list">
-      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a></li>
+      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-thinlines.svg" alt="LM logo"></a></li>
       <li><a href="/">Home</a></li>
       <li><a href="/about/">About</a></li>
       <li><a href="/projects/">Projects</a></li>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
   </label>
   <nav>
     <ul class="nav-list">
-      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a></li>
+      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-thinlines.svg" alt="LM logo"></a></li>
       <li><a href="/" class="active">Home</a></li>
       <li><a href="/about/">About</a></li>
       <li><a href="/projects/">Projects</a></li>

--- a/photos/index.html
+++ b/photos/index.html
@@ -22,7 +22,7 @@
   </label>
   <nav>
     <ul class="nav-list">
-      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a></li>
+      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-thinlines.svg" alt="LM logo"></a></li>
       <li><a href="/">Home</a></li>
       <li><a href="/about/">About</a></li>
       <li><a href="/projects/">Projects</a></li>

--- a/projects/index.html
+++ b/projects/index.html
@@ -22,7 +22,7 @@
   </label>
   <nav>
     <ul class="nav-list">
-      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a></li>
+      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-thinlines.svg" alt="LM logo"></a></li>
       <li><a href="/">Home</a></li>
       <li><a href="/about/">About</a></li>
       <li><a href="/projects/" class="active">Projects</a></li>

--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -22,7 +22,7 @@
   </label>
   <nav>
     <ul class="nav-list">
-      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a></li>
+      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-thinlines.svg" alt="LM logo"></a></li>
       <li><a href="/">Home</a></li>
       <li><a href="/about/">About</a></li>
       <li><a href="/projects/" class="active">Projects</a></li>

--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -22,7 +22,7 @@
   </label>
   <nav>
     <ul class="nav-list">
-      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a></li>
+      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-thinlines.svg" alt="LM logo"></a></li>
       <li><a href="/">Home</a></li>
       <li><a href="/about/">About</a></li>
       <li><a href="/projects/">Projects</a></li>

--- a/works/assume/index.html
+++ b/works/assume/index.html
@@ -22,7 +22,7 @@
   </label>
   <nav>
     <ul class="nav-list">
-      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a></li>
+      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-thinlines.svg" alt="LM logo"></a></li>
       <li><a href="/">Home</a></li>
       <li><a href="/about/">About</a></li>
       <li><a href="/projects/">Projects</a></li>

--- a/works/bodylines/index.html
+++ b/works/bodylines/index.html
@@ -22,7 +22,7 @@
   </label>
   <nav>
     <ul class="nav-list">
-      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a></li>
+      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-thinlines.svg" alt="LM logo"></a></li>
       <li><a href="/">Home</a></li>
       <li><a href="/about/">About</a></li>
       <li><a href="/projects/">Projects</a></li>

--- a/works/index.html
+++ b/works/index.html
@@ -22,7 +22,7 @@
   </label>
   <nav>
     <ul class="nav-list">
-      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a></li>
+      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-thinlines.svg" alt="LM logo"></a></li>
       <li><a href="/">Home</a></li>
       <li><a href="/about/">About</a></li>
       <li><a href="/projects/">Projects</a></li>

--- a/works/internal/index.html
+++ b/works/internal/index.html
@@ -22,7 +22,7 @@
   </label>
   <nav>
     <ul class="nav-list">
-      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a></li>
+      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-thinlines.svg" alt="LM logo"></a></li>
       <li><a href="/">Home</a></li>
       <li><a href="/about/">About</a></li>
       <li><a href="/projects/">Projects</a></li>

--- a/works/occlusion/index.html
+++ b/works/occlusion/index.html
@@ -22,7 +22,7 @@
   </label>
   <nav>
     <ul class="nav-list">
-      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-favicon.svg" alt="LM logo"></a></li>
+      <li class="nav-logo"><a href="/"><img src="/assets/logos/lm-logo-thinlines.svg" alt="LM logo"></a></li>
       <li><a href="/">Home</a></li>
       <li><a href="/about/">About</a></li>
       <li><a href="/projects/">Projects</a></li>


### PR DESCRIPTION
## Summary
- Replace dropdown navigation logo with thinlines SVG across site pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1ed11fd6c832dbf319f440020a154