### PR TITLE
Ensure menu blocks page scroll on iOS

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -2,8 +2,19 @@ window.addEventListener('DOMContentLoaded', () => {
   const menuToggle = document.getElementById('menu-toggle');
   if (!menuToggle) return;
 
+  let scrollPosition = 0;
   const updateScrollLock = () => {
-    document.body.style.overflow = menuToggle.checked ? 'hidden' : '';
+    if (menuToggle.checked) {
+      scrollPosition = window.scrollY;
+      document.body.style.position = 'fixed';
+      document.body.style.top = `-${scrollPosition}px`;
+      document.documentElement.style.overflow = 'hidden';
+    } else {
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.documentElement.style.overflow = '';
+      window.scrollTo(0, scrollPosition);
+    }
   };
 
   menuToggle.addEventListener('change', updateScrollLock);


### PR DESCRIPTION
## Summary
- prevent page scroll while mobile menu open by fixing body position and storing scroll location

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1f0c33e20832d92d4340c9f7d112b