### PR TITLE
Fix mobile menu visibility on navigation

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -19,6 +19,16 @@ window.addEventListener('DOMContentLoaded', () => {
 
   menuToggle.addEventListener('change', updateScrollLock);
 
+  // Close the menu when a navigation link is clicked
+  document.querySelectorAll('nav a').forEach((link) => {
+    link.addEventListener('click', () => {
+      if (menuToggle.checked) {
+        menuToggle.checked = false;
+        updateScrollLock();
+      }
+    });
+  });
+
   document.addEventListener('click', (e) => {
     if (!menuToggle.checked) return;
     const header = document.querySelector('header');


### PR DESCRIPTION
## Summary
- Close the mobile menu when a navigation link is tapped
- Ensure scroll lock state resets when navigating between pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2175980c0832d861b75050001cbc6