### PR TITLE
Disable enlarging photo on About page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -44,7 +44,7 @@
           <p>He studied composition with <a href="http://www.colombotaccani.it" target="_blank">Giorgio Colombo Taccani</a> in Turin (2019–2021) and <a href="http://www.marcomomi.com" target="_blank">Marco Momi</a> in Fermo (2021–2023), and is now pursuing a Master's degree under <a href="https://fr.wikipedia.org/wiki/Franck_Bedrossian" target="_blank">Franck Bedrossian</a> at <a href="https://www.kug.ac.at/en" target="_blank">Kunstuniversität Graz</a>.</p>
         </div>
         <div class="about-photo">
-          <img src="/assets/graphics/photo-LC-1-bw.jpg" alt="Portrait of Leonardo Matteucci" loading="lazy" data-enlargeable>
+          <img src="/assets/graphics/photo-LC-1-bw.jpg" alt="Portrait of Leonardo Matteucci" loading="lazy">
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Prevent About page portrait from opening the photo-preview modal by removing the `data-enlargeable` attribute.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb791c60c832d955c866042bf86d6