### PR TITLE
Fix excess vertical spacing in about bio

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -758,6 +758,13 @@ main{
   text-align: left;
 
 }
+.about-bio p{
+  margin: 0;
+}
+
+.about-bio p + p{
+  margin-top: 1em;
+}
 .about-photo{
   max-width: 350px;
 }


### PR DESCRIPTION
## Summary
- Remove default top and bottom margins from about-page bio paragraphs for consistent padding
- Keep spacing between paragraphs with a separate margin rule

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acc3522ad8832d9baae4baf569653b