### PR TITLE
Limit about bio card width

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -751,6 +751,7 @@ main{
 }
 .about-bio{
   width: 100%;
+  max-width: calc((1000px - 64px) / 3);
   padding: 24px;
   background: var(--card-bg-start);
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Restrict about page bio card width to match project card proportions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc5c57abc832d93b66f36d91a6d97