### PR TITLE
Refine About page layout and bio

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -40,7 +40,9 @@
       <h1 class="works-title">About</h1>
       <div class="works-grid about-grid">
         <article class="work-card">
-          <p><a href="/">Leonardo Matteucci</a> (b. 2000) is an Italian composer currently exploring inner corporeality, the mechanics of bodily articulation, and the tactility of acoustic-electronic hybridisation.</p>
+          <h3>Bio</h3>
+          <p><span class="tag">b. 2000</span><span class="tag">Perugia</span></p>
+          <p>Leonardo Matteucci is an Italian composer currently exploring inner corporeality, the mechanics of bodily articulations, and the tactility of acoustic-electronic hybridisation.</p>
         </article>
         <figure class="work-card">
           <img src="/assets/graphics/photo-LC-1-bw.jpg" alt="Portrait of Leonardo Matteucci" loading="lazy">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -221,9 +221,8 @@ nav{
   margin-bottom: 32px;
 }
 
-.about-grid{
-  max-width: calc(3 * 250px + 2 * 32px);
-  margin: 0 auto;
+.about-grid .tag{
+  display: block;
 }
 
 /* Cards */


### PR DESCRIPTION
## Summary
- Add bio card with birth year and hometown tags
- Ensure tags on About page break onto new lines
- Remove width constraint so About page cards match Works section

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acd1b5078c832d8734ec78f5980867