### PR TITLE
Update Rivedere instrumentation listing

### DIFF
--- a/works/index.html
+++ b/works/index.html
@@ -42,7 +42,7 @@
       <div class="works-grid">
         <article class="work-card upcoming">
           <h3>Rivedere<span class="works-details">2027</span></h3>
-          <p><span class="tag">flute</span><span class="tag">oboe</span><span class="tag">clarinet</span><span class="tag">trumpet</span><span class="tag">trombone</span><span class="tag">percussion</span><span class="tag">piano</span><span class="tag">violin</span><span class="tag">viola</span><span class="tag">cello</span><span class="tag">electronics</span></p>
+          <p><span class="tag">flute</span><span class="tag">clarinet</span><span class="tag">trumpet</span><span class="tag">trombone</span><span class="tag">percussion</span><span class="tag">harp</span><span class="tag">piano</span><span class="tag">violin</span><span class="tag">cello</span><span class="tag">electronics</span></p>
         </article>
         <article class="work-card">
           <h3><a href="/works/assume/">Assume</a><span class="works-details">2025</span></h3>


### PR DESCRIPTION
### Motivation
- Update the public works listing to reflect the corrected instrumentation for Rivedere (2027): flute, clarinet, trumpet, trombone, percussion, harp, piano, violin, cello, electronics.

### Description
- Changed instrumentation tags in `works/index.html` by replacing `oboe` and `viola` with `harp` and arranging tags as `flute`, `clarinet`, `trumpet`, `trombone`, `percussion`, `harp`, `piano`, `violin`, `cello`, `electronics`.

### Testing
- No automated tests were run for this content-only HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a006c771c10832db7b8b8ddf4fd97ab)