### PR TITLE
Update Reach.Touch support text

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -122,7 +122,7 @@
         </figure>
       </div>
       <hr class="separator">
-      <p class="works-details italic align-right"><a href="/projects/reach-touch/index.html" target="_blank" rel="noopener noreferrer" style="font-style: normal;">Reach.Touch.</a> is a concert project supported by <a href="https://www.kultur.steiermark.at/" target="_blank" rel="noopener noreferrer">Land Steiermark</a>, <a href="https://www.oehkug.at/" target="_blank" rel="noopener noreferrer">ÖH-KUG</a>, and the <a href="https://www.kug.ac.at/en/" target="_blank" rel="noopener noreferrer">Kunstuniversität Graz</a></p>
+      <p class="works-details italic align-right">The 2025 edition of Reach.Touch. was made possible with support from the Hinker-Fonds, Land Steiermark, the ÖH-KUG Sonderprojekttopf, and the Kunstuniversität Graz.</p>
     </section>
   </div>
 </main>


### PR DESCRIPTION
### Motivation
- Update the support acknowledgement on the Reach.Touch. project page to the requested 2025 edition wording while preserving the page’s existing styling.

### Description
- Replaced the support paragraph in `projects/reach-touch/index.html` with the sentence: “The 2025 edition of Reach.Touch. was made possible with support from the Hinker-Fonds, Land Steiermark, the ÖH-KUG Sonderprojekttopf, and the Kunstuniversität Graz.” and preserved the element classes `works-details italic align-right`.

### Testing
- Ran `git diff --check` and `git status --short`, which reported no issues and show the modified file in the working tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a573873d3c8832dbca101308d1d8a76)