### PR TITLE
Update Reach.Touch. sponsorship copy for 2025 edition

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -122,7 +122,7 @@
         </figure>
       </div>
       <hr class="separator">
-      <p class="works-details italic align-right"><a href="/projects/reach-touch/index.html" target="_blank" rel="noopener noreferrer" style="font-style: normal;">Reach.Touch.</a> is a concert project supported by <a href="https://www.kultur.steiermark.at/" target="_blank" rel="noopener noreferrer">Land Steiermark</a>, <a href="https://www.oehkug.at/" target="_blank" rel="noopener noreferrer">ÖH-KUG</a>, and the <a href="https://www.kug.ac.at/en/" target="_blank" rel="noopener noreferrer">Kunstuniversität Graz</a></p>
+      <p class="works-details italic align-right">The 2025 edition of <span style="font-style: normal;">Reach.Touch.</span> was made possible with support from the <span style="font-style: normal;">Hinker-Fonds</span>, <a href="https://www.kultur.steiermark.at/" target="_blank" rel="noopener noreferrer" style="font-style: normal;">Land Steiermark</a>, the <a href="https://www.oehkug.at/" target="_blank" rel="noopener noreferrer" style="font-style: normal;">ÖH-KUG Sonderprojekttopf</a>, and the <a href="https://www.kug.ac.at/en/" target="_blank" rel="noopener noreferrer" style="font-style: normal;">Kunstuniversität Graz</a>.</p>
     </section>
   </div>
 </main>


### PR DESCRIPTION
### Motivation
- Update the program page to reflect the 2025 edition sponsors and clarify the support language in `projects/reach-touch/index.html`.

### Description
- Replace the previous right-aligned sponsor line with new copy that credits the `Hinker-Fonds`, `Land Steiermark`, `ÖH-KUG Sonderprojekttopf`, and the `Kunstuniversität Graz`, and adjust inline styling for display.

### Testing
- No automated tests were added or modified; the change is a static HTML text update and was verified by inspecting the updated `projects/reach-touch/index.html` markup for correct output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a573873d3c8832dbca101308d1d8a76)