### PR TITLE
Add brochure credit to Reach.Touch. project page

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -121,6 +121,7 @@
           <img src="/assets/graphics/RT-brochure-2.png" alt="Reach.Touch. brochure page two">
         </figure>
       </div>
+      <p class="works-details italic align-right">Graphic design and layout: Leonardo Matteucci</p>
       <hr class="separator">
       <p class="works-details italic align-right">The 2025 edition of Reach.Touch. was made possible with support from the Hinker-Fonds, Land Steiermark, the ÖH-KUG Sonderprojekttopf, and the Kunstuniversität Graz.</p>
     </section>


### PR DESCRIPTION
### Motivation
- Add a graphic-design credit line directly beneath the brochure image gallery on the Reach.Touch. project page to attribute layout work.

### Description
- Inserted a new paragraph directly after the `div.brochure-gallery` in `projects/reach-touch/index.html`: `<p class="works-details italic align-right">Graphic design and layout: Leonardo Matteucci</p>` to match existing typography and spacing.

### Testing
- Ran `git diff --check` and `git status --short` to validate the change and committed the modification to `projects/reach-touch/index.html` (one insertion), both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a573ba8ce20832da1445af45b5cb2e8)