### PR TITLE
Add graphic design credit to Reach.Touch. project page

### DIFF
--- a/projects/reach-touch/index.html
+++ b/projects/reach-touch/index.html
@@ -121,6 +121,7 @@
           <img src="/assets/graphics/RT-brochure-2.png" alt="Reach.Touch. brochure page two">
         </figure>
       </div>
+      <p class="works-details align-right">Graphic design and layout: Leonardo Matteucci</p>
       <hr class="separator">
       <p class="works-details italic align-right">The 2025 edition of Reach.Touch. was made possible with support from the Hinker-Fonds, Land Steiermark, the ÖH-KUG Sonderprojekttopf, and the Kunstuniversität Graz.</p>
     </section>


### PR DESCRIPTION
### Motivation
- Add a visible credit for graphic design and layout on the Reach.Touch. project page to acknowledge the designer and accompany the brochure images.

### Description
- Inserted a new `<p>` element in `projects/reach-touch/index.html` with classes `works-details` and `align-right` containing the text "Graphic design and layout: Leonardo Matteucci".

### Testing
- No automated tests were run for this small HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a573ba8ce20832da1445af45b5cb2e8)