### PR TITLE
Update “A uno spirituale in Firenze” program notes

### DIFF
--- a/works/a-uno-spirituale-in-firenze/index.html
+++ b/works/a-uno-spirituale-in-firenze/index.html
@@ -54,11 +54,12 @@
       </ul>
       <p class="works-premiere">Premiere: 29 October 2021, Serate Musicali, Turin Conservatory</p>
       <hr class="separator">
-      <p class="italic">Five aphorisms inspired by an excerpt from the homonymous letter by Saint Catherine of Siena, addressed "to a devotee who was scandalized by her abstinences." This letter is taken from the second volume of a collection edited by Niccolò Tommaseo and published in Florence in 1860 by G. Barbèra.</p>
+      <p class="italic">Five aphorisms inspired by excerpts from a letter of the same title (<em>A uno spirituale in Firenze</em>) by Saint Catherine of Siena, addressed “to a devotee who was scandalized by her abstinences.”</p>
+      <p class="italic">The letter appears in the second volume of a collection edited by Niccolò Tommaseo and published by G. Barbèra in Florence in 1860.</p>
       <ol>
         <li><em>«[…] e prego Dio e pregherò, che mi dia grazia che in quest’atto del mangiare io viva come le altre creature […]»</em><br>“[…] and I pray and will continue to pray to God to grant me the grace to live, in this act of eating, as other creatures do […]”</li>
         <li><em>«[…] e Dio che per singolarissima grazia m’abbia fatto correggere il vizio della gola […]»</em><br>“[…] and God who, through a most singular grace, has allowed me to correct the vice of gluttony […]”</li>
-        <li><em>«[…] Io per me non so che altro rimedio ponermici, … se non ch’io prego voi che preghiate quella somma eterna Verità […]»</em><br>“[…] As for myself, I do not know what other remedy I can apply, except to ask you to pray to that supreme eternal Truth […]”</li>
+        <li><em>«[…] Io per me non so che altro rimedio ponermici, se non ch’io prego voi che preghiate quella somma eterna Verità […]»</em><br>“[…] As for myself, I do not know what other remedy I can apply, except to ask you to pray to that supreme eternal Truth […]”</li>
         <li><em>«E io son certa, che la bontà di Dio non spregierà le vostre orazioni.»</em><br>“And I am certain that the goodness of God will not despise your prayers.”</li>
         <li><em>«[…] che mi dia grazia, […] che mi faccia prendere il cibo, se gli piace.»</em><br>“[…] that He may grant me the grace […] to partake of food, if it pleases Him.”</li>
       </ol>


### PR DESCRIPTION
### Motivation
- Replace the current program-note text and the five bilingual excerpts on the work page with the definitive supplied wording while preserving the page title, layout, typography, semantic HTML structure, and existing Italian/English pairing and punctuation.

### Description
- Edit made to `works/a-uno-spirituale-in-firenze/index.html`: the introductory program-note was replaced with two `<p class="italic">` paragraphs, the work title is italicized using `<em>`, the third Italian excerpt was corrected to remove the unintended ellipsis between “ponermici,” and “se non”, and the five bilingual `<li>` pairings and `<ol>` structure were preserved (diff: 3 insertions, 2 deletions).

### Testing
- Ran `python -m pytest` (1 test passed), validated the edited HTML with Python's `html.parser`, executed targeted assertions confirming the definitive copy and five-item ordered-list structure, and ran `git diff --check`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7097a78d74832d9ab6e6865e81bfb9)